### PR TITLE
StringLiteral.textSourceNode cannot be PrivateName

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1188,7 +1188,7 @@ namespace ts {
 
     export interface StringLiteral extends LiteralExpression {
         kind: SyntaxKind.StringLiteral;
-        /* @internal */ textSourceNode?: Identifier | PrivateName | StringLiteralLike | NumericLiteral; // Allows a StringLiteral to get its text from another node (used by transforms).
+        /* @internal */ textSourceNode?: Identifier | StringLiteralLike | NumericLiteral; // Allows a StringLiteral to get its text from another node (used by transforms).
         /** Note: this is only set when synthesizing a node, not during parsing. */
         /* @internal */ singleQuote?: boolean;
     }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2650,7 +2650,6 @@ namespace ts {
     export function isPropertyNameLiteral(node: Node): node is PropertyNameLiteral {
         switch (node.kind) {
             case SyntaxKind.Identifier:
-            // TODO: should this be here?
             case SyntaxKind.PrivateName:
             case SyntaxKind.StringLiteral:
             case SyntaxKind.NoSubstitutionTemplateLiteral:


### PR DESCRIPTION
Undo an accidental change that made it so
StringLiteral.textSourceNode could be a private
name.

All tests should still pass.

Signed-off-by: Max Heiber <max.heiber@gmail.com>