### PR TITLE
Fix display of private names in the TS Language Server

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4171,7 +4171,10 @@ namespace ts {
                         context.flags ^= NodeBuilderFlags.InInitialEntityName;
                     }
                     let firstChar = symbolName.charCodeAt(0);
-                    const canUsePropertyAccess = isIdentifierStart(firstChar, languageVersion);
+                    const canUsePropertyAccess = firstChar === CharacterCodes.hash ?
+                        symbolName.length > 1 && isIdentifierStart(symbolName.charCodeAt(1), languageVersion) :
+                        isIdentifierStart(firstChar, languageVersion);
+
                     if (index === 0 || canUsePropertyAccess) {
                         const identifier = setEmitFlags(createIdentifier(symbolName, typeParameterNodes), EmitFlags.NoAsciiEscaping);
                         identifier.symbol = symbol;

--- a/tests/baselines/reference/privateNameField.symbols
+++ b/tests/baselines/reference/privateNameField.symbols
@@ -3,13 +3,13 @@ class A {
 >A : Symbol(A, Decl(privateNameField.ts, 0, 0))
 
     #name: string;
->#name : Symbol(A[#name], Decl(privateNameField.ts, 0, 9))
+>#name : Symbol(A.#name, Decl(privateNameField.ts, 0, 9))
 
     constructor(name: string) {
 >name : Symbol(name, Decl(privateNameField.ts, 2, 16))
 
         this.#name = name;
->this.#name : Symbol(A[#name], Decl(privateNameField.ts, 0, 9))
+>this.#name : Symbol(A.#name, Decl(privateNameField.ts, 0, 9))
 >this : Symbol(A, Decl(privateNameField.ts, 0, 0))
 >name : Symbol(name, Decl(privateNameField.ts, 2, 16))
     }


### PR DESCRIPTION
The language server was displaying private names in the form of `A[#privateName]` instead of `A.#privateName`. (One place where this is visible is when you hover over a private name in VSCode.) This change to the checker will use the property access with private names instead of element access. 