### PR TITLE
Error on Private Names (for now)

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4303,9 +4303,13 @@
         "category": "Error",
         "code": 18004
     },
-    "Private names cannot be used as parameters": {
+    "Private names cannot be used as parameters.": {
         "category": "Error",
         "code": 18005
+    },
+    "Private names are not currently supported.": {
+        "category": "Error",
+        "code": 18006
     },
 
     "File is a CommonJS module; it may be converted to an ES6 module.": {

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1372,6 +1372,7 @@ namespace ts {
                 return parseComputedPropertyName();
             }
             if (token() === SyntaxKind.PrivateName) {
+                parseErrorAtCurrentToken(Diagnostics.Private_names_are_not_currently_supported);
                 return parsePrivateName();
             }
             return parseIdentifierName();

--- a/tests/baselines/reference/privateNameField.errors.txt
+++ b/tests/baselines/reference/privateNameField.errors.txt
@@ -1,0 +1,12 @@
+tests/cases/conformance/classes/members/privateNames/privateNameField.ts(2,5): error TS18006: Private names are not currently supported.
+
+
+==== tests/cases/conformance/classes/members/privateNames/privateNameField.ts (1 errors) ====
+    class A {
+        #name: string;
+        ~~~~~
+!!! error TS18006: Private names are not currently supported.
+        constructor(name: string) {
+            this.#name = name;
+        }
+    }


### PR DESCRIPTION
Issue diagnostic error for private names,
"Private names are not currently supported."

This is part of the strategy of working toward
getting feedback on the feature without including
it in stable yet.

Signed-off-by: Max Heiber <mheiber@bloomberg.net>