### PR TITLE
Private named instance fields `.d.ts` emit for `.js` files

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5572,7 +5572,26 @@ namespace ts {
                     const staticType = getTypeOfSymbol(symbol);
                     const staticBaseType = getBaseConstructorTypeOfClass(staticType as InterfaceType);
                     const heritageClauses = !length(baseTypes) ? undefined : [createHeritageClause(SyntaxKind.ExtendsKeyword, map(baseTypes, b => serializeBaseType(b, staticBaseType, localName)))];
-                    const members = flatMap<Symbol, ClassElement>(getPropertiesOfType(classType), p => serializePropertySymbolForClass(p, /*isStatic*/ false, baseTypes[0]));
+                    const symbolProps = getPropertiesOfType(classType);
+                    const publicSymbolProps = filter(symbolProps, s => {
+                        const valueDecl = s.valueDeclaration;
+                        Debug.assertDefined(valueDecl);
+                        return isClassElement(valueDecl) && isNamedDeclaration(valueDecl)
+                            && !isPrivateIdentifier(valueDecl.name);
+                    });
+                    const hasPrivateField = symbolProps !== publicSymbolProps;
+                    // Boil down all private properties into a single one.
+                    const privateProperties = hasPrivateField ?
+                        [createProperty(
+                            /*decorators*/ undefined,
+                            /*modifiers*/ undefined,
+                            createPrivateIdentifier("#private"),
+                            /*questionOrExclamationToken*/ undefined,
+                            /*type*/ undefined,
+                            /*initializer*/ undefined,
+                        )] :
+                        emptyArray;
+                    const publicProperties = flatMap<Symbol, ClassElement>(publicSymbolProps, p => serializePropertySymbolForClass(p, /*isStatic*/ false, baseTypes[0]));
                     // Consider static members empty if symbol also has function or module meaning - function namespacey emit will handle statics
                     const staticMembers = symbol.flags & (SymbolFlags.Function | SymbolFlags.ValueModule)
                         ? []
@@ -5594,7 +5613,7 @@ namespace ts {
                         localName,
                         typeParamDecls,
                         heritageClauses,
-                        [...indexSignatures, ...staticMembers, ...constructors, ...members]
+                        [...indexSignatures, ...staticMembers, ...constructors, ...publicProperties, ...privateProperties]
                     ), symbol.declarations && filter(symbol.declarations, d => isClassDeclaration(d) || isClassExpression(d))[0]), modifierFlags);
                 }
 

--- a/tests/baselines/reference/jsDeclarationsPrivateFields01.js
+++ b/tests/baselines/reference/jsDeclarationsPrivateFields01.js
@@ -1,0 +1,35 @@
+//// [file.js]
+export class C {
+    #hello = "hello";
+    #world = 100;
+
+    #calcHello() {
+        return this.#hello;
+    }
+
+    get #screamingHello() {
+        return this.#hello.toUpperCase();
+    }
+    /** @param value {string} */
+    set #screamingHello(value) {
+        throw "NO";
+    }
+
+    getWorld() {
+        return this.#world;
+    }
+}
+
+
+
+
+//// [file.d.ts]
+export class C {
+    "__#1@#hello": string;
+    "__#1@#world": number;
+    "__#1@#calcHello"(): string;
+    /** @param value {string} */
+    set "__#1@#screamingHello"(arg: string);
+    get "__#1@#screamingHello"(): string;
+    getWorld(): number;
+}

--- a/tests/baselines/reference/jsDeclarationsPrivateFields01.js
+++ b/tests/baselines/reference/jsDeclarationsPrivateFields01.js
@@ -25,11 +25,6 @@ export class C {
 
 //// [file.d.ts]
 export class C {
-    "__#1@#hello": string;
-    "__#1@#world": number;
-    "__#1@#calcHello"(): string;
-    /** @param value {string} */
-    set "__#1@#screamingHello"(arg: string);
-    get "__#1@#screamingHello"(): string;
     getWorld(): number;
+    #private;
 }

--- a/tests/baselines/reference/jsDeclarationsPrivateFields01.symbols
+++ b/tests/baselines/reference/jsDeclarationsPrivateFields01.symbols
@@ -1,0 +1,44 @@
+=== tests/cases/conformance/jsdoc/declarations/file.js ===
+export class C {
+>C : Symbol(C, Decl(file.js, 0, 0))
+
+    #hello = "hello";
+>#hello : Symbol(C.#hello, Decl(file.js, 0, 16))
+
+    #world = 100;
+>#world : Symbol(C.#world, Decl(file.js, 1, 21))
+
+    #calcHello() {
+>#calcHello : Symbol(C.#calcHello, Decl(file.js, 2, 17))
+
+        return this.#hello;
+>this.#hello : Symbol(C.#hello, Decl(file.js, 0, 16))
+>this : Symbol(C, Decl(file.js, 0, 0))
+    }
+
+    get #screamingHello() {
+>#screamingHello : Symbol(C.#screamingHello, Decl(file.js, 6, 5), Decl(file.js, 10, 5))
+
+        return this.#hello.toUpperCase();
+>this.#hello.toUpperCase : Symbol(String.toUpperCase, Decl(lib.es5.d.ts, --, --))
+>this.#hello : Symbol(C.#hello, Decl(file.js, 0, 16))
+>this : Symbol(C, Decl(file.js, 0, 0))
+>toUpperCase : Symbol(String.toUpperCase, Decl(lib.es5.d.ts, --, --))
+    }
+    /** @param value {string} */
+    set #screamingHello(value) {
+>#screamingHello : Symbol(C.#screamingHello, Decl(file.js, 6, 5), Decl(file.js, 10, 5))
+>value : Symbol(value, Decl(file.js, 12, 24))
+
+        throw "NO";
+    }
+
+    getWorld() {
+>getWorld : Symbol(C.getWorld, Decl(file.js, 14, 5))
+
+        return this.#world;
+>this.#world : Symbol(C.#world, Decl(file.js, 1, 21))
+>this : Symbol(C, Decl(file.js, 0, 0))
+    }
+}
+

--- a/tests/baselines/reference/jsDeclarationsPrivateFields01.types
+++ b/tests/baselines/reference/jsDeclarationsPrivateFields01.types
@@ -1,0 +1,48 @@
+=== tests/cases/conformance/jsdoc/declarations/file.js ===
+export class C {
+>C : C
+
+    #hello = "hello";
+>#hello : string
+>"hello" : "hello"
+
+    #world = 100;
+>#world : number
+>100 : 100
+
+    #calcHello() {
+>#calcHello : () => string
+
+        return this.#hello;
+>this.#hello : string
+>this : this
+    }
+
+    get #screamingHello() {
+>#screamingHello : string
+
+        return this.#hello.toUpperCase();
+>this.#hello.toUpperCase() : string
+>this.#hello.toUpperCase : () => string
+>this.#hello : string
+>this : this
+>toUpperCase : () => string
+    }
+    /** @param value {string} */
+    set #screamingHello(value) {
+>#screamingHello : string
+>value : string
+
+        throw "NO";
+>"NO" : "NO"
+    }
+
+    getWorld() {
+>getWorld : () => number
+
+        return this.#world;
+>this.#world : number
+>this : this
+    }
+}
+

--- a/tests/cases/conformance/jsdoc/declarations/jsDeclarationsPrivateFields01.ts
+++ b/tests/cases/conformance/jsdoc/declarations/jsDeclarationsPrivateFields01.ts
@@ -1,0 +1,26 @@
+// @target: esnext
+// @allowJS: true
+// @declaration: true
+// @emitDeclarationOnly: true
+
+// @filename: file.js
+export class C {
+    #hello = "hello";
+    #world = 100;
+
+    #calcHello() {
+        return this.#hello;
+    }
+
+    get #screamingHello() {
+        return this.#hello.toUpperCase();
+    }
+    /** @param value {string} */
+    set #screamingHello(value) {
+        throw "NO";
+    }
+
+    getWorld() {
+        return this.#world;
+    }
+}


### PR DESCRIPTION
@weswigham mentioned that the private fields PR probably doesn't handle `.js` emit correctly. I don't think it's a blocker, but here's the fix.

CC @ryancavanaugh