### PR TITLE
`PrivateIdentifier` inclusion in `isPropertyName`

### DIFF
--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -1801,6 +1801,7 @@ namespace ts {
     export function isPropertyName(node: Node): node is PropertyName {
         const kind = node.kind;
         return kind === SyntaxKind.Identifier
+            || kind === SyntaxKind.PrivateIdentifier
             || kind === SyntaxKind.StringLiteral
             || kind === SyntaxKind.NumericLiteral
             || kind === SyntaxKind.ComputedPropertyName;


### PR DESCRIPTION
**Describe your changes**
`PrivateIdentifier` is part of the union of types making up `PropertyName` but the `isPropertyName` type predicate does not currently include it.
This change adds `PrivateIdentifier` to the list of kinds checks in `isPropertyName`.