### PR TITLE
Watch extended config files

### DIFF
--- a/src/compiler/watchPublic.ts
+++ b/src/compiler/watchPublic.ts
@@ -246,6 +246,7 @@ namespace ts {
 
         let builderProgram: T;
         let reloadLevel: ConfigFileProgramReloadLevel;                      // level to indicate if the program needs to be reloaded from config file/just filenames etc
+        let extendedConfigFilesMap: ESMap<Path, FileWatcher>;               // Map of file watchers for the extended config files
         let missingFilesMap: ESMap<Path, FileWatcher>;                        // Map of file watchers for the missing files
         let watchedWildcardDirectories: ESMap<string, WildcardDirectoryWatcher>; // map of watchers for the wild card directories in the config file
         let timerToUpdateProgram: any;                                      // timer callback to recompile the program
@@ -354,6 +355,10 @@ namespace ts {
                 configFileWatcher.close();
                 configFileWatcher = undefined;
             }
+            if (extendedConfigFilesMap) {
+                clearMap(extendedConfigFilesMap, closeFileWatcher);
+                extendedConfigFilesMap = undefined!;
+            }
             if (watchedWildcardDirectories) {
                 clearMap(watchedWildcardDirectories, closeFileWatcherOf);
                 watchedWildcardDirectories = undefined!;
@@ -419,6 +424,7 @@ namespace ts {
             resolutionCache.finishCachingPerDirectoryResolution();
 
             // Update watches
+            updateExtendedConfigFilePathsWatch(builderProgram.getProgram(), extendedConfigFilesMap || (extendedConfigFilesMap = new Map()), watchExtendedConfigFile);
             updateMissingFilePathsWatch(builderProgram.getProgram(), missingFilesMap || (missingFilesMap = new Map()), watchMissingFilePath);
             if (needsUpdateInTypeRootWatch) {
                 resolutionCache.updateTypeRootsWatch();
@@ -693,6 +699,10 @@ namespace ts {
             if (cachedDirectoryStructureHost) {
                 cachedDirectoryStructureHost.addOrDeleteFile(fileName, path, eventKind);
             }
+        }
+
+        function watchExtendedConfigFile(extendedConfigFile: string) {
+            return watchFile(host, extendedConfigFile, scheduleProgramReload, PollingInterval.High, watchOptions, WatchType.ConfigFile);
         }
 
         function watchMissingFilePath(missingFilePath: Path) {

--- a/src/compiler/watchUtilities.ts
+++ b/src/compiler/watchUtilities.ts
@@ -258,6 +258,30 @@ namespace ts {
     }
 
     /**
+     * Updates the extended config file watches with the new set of extended config files after new program is created
+     */
+    export function updateExtendedConfigFilePathsWatch(
+        program: Program,
+        extendedConfigFilesMap: ESMap<string, FileWatcher>,
+        createExtendedConfigFileWatch: (extendedConfigPath: string) => FileWatcher,
+    ) {
+        const extendedSourceFiles = program.getCompilerOptions().configFile?.extendedSourceFiles || [];
+        // TODO(rbuckton): Should be a `Set` but that requires changing the below code that uses `mutateMap`
+        const newExtendedConfigFilesMap = arrayToMap(extendedSourceFiles, identity, returnTrue);
+        // Update the extended config files watcher
+        mutateMap(
+            extendedConfigFilesMap,
+            newExtendedConfigFilesMap,
+            {
+                // Watch the extended config files
+                createNewValue: createExtendedConfigFileWatch,
+                // Config files that are no longer extended should no longer be watched.
+                onDeleteValue: closeFileWatcher
+            }
+        );
+    }
+
+    /**
      * Updates the existing missing file watches with the new set of missing files after new program is created
      */
     export function updateMissingFilePathsWatch(

--- a/src/testRunner/unittests/tscWatch/watchEnvironment.ts
+++ b/src/testRunner/unittests/tscWatch/watchEnvironment.ts
@@ -412,5 +412,103 @@ namespace ts.tscWatch {
                 changes: emptyArray
             });
         });
+
+        describe("handles watch for extended configs", () => {
+            verifyTscWatch({
+                scenario,
+                subScenario: "watchExtends/with watchFile option",
+                commandLineArgs: ["-w", "-p", "/a/b/tsconfig.json"],
+                sys: () => {
+                    const extendedFile: File = {
+                        path: "/a/b/extended.tsconfig.json",
+                        content: JSON.stringify({
+                            watchOptions: {
+                                watchFile: "UseFsEvents"
+                            }
+                        })
+                    };
+                    const configFile: File = {
+                        path: "/a/b/tsconfig.json",
+                        content: JSON.stringify({
+                            extends: "./extended.tsconfig.json"
+                        })
+                    };
+                    const files = [libFile, commonFile1, commonFile2, extendedFile, configFile];
+                    return createWatchedSystem(files);
+                },
+                changes: emptyArray
+            });
+
+            verifyTscWatch({
+                scenario,
+                subScenario: "watchExtends/with watchDirectory option",
+                commandLineArgs: ["-w", "-p", "/a/b/tsconfig.json"],
+                sys: () => {
+                    const extendedFile: File = {
+                        path: "/a/b/extended.tsconfig.json",
+                        content: JSON.stringify({
+                            watchOptions: {
+                                watchDirectory: "UseFsEvents"
+                            }
+                        })
+                    };
+                    const configFile: File = {
+                        path: "/a/b/tsconfig.json",
+                        content: JSON.stringify({
+                            extends: "./extended.tsconfig.json"
+                        })
+                    };
+                    const files = [libFile, commonFile1, commonFile2, extendedFile, configFile];
+                    return createWatchedSystem(files, { runWithoutRecursiveWatches: true });
+                },
+                changes: emptyArray
+            });
+
+            verifyTscWatch({
+                scenario,
+                subScenario: "watchExtends/with fallbackPolling option",
+                commandLineArgs: ["-w", "-p", "/a/b/tsconfig.json"],
+                sys: () => {
+                    const extendedFile: File = {
+                        path: "/a/b/extended.tsconfig.json",
+                        content: JSON.stringify({
+                            watchOptions: {
+                                fallbackPolling: "PriorityInterval"
+                            }
+                        })
+                    };
+                    const configFile: File = {
+                        path: "/a/b/tsconfig.json",
+                        content: JSON.stringify({
+                            extends: "./extended.tsconfig.json"
+                        })
+                    };
+                    const files = [libFile, commonFile1, commonFile2, extendedFile, configFile];
+                    return createWatchedSystem(files, { runWithoutRecursiveWatches: true, runWithFallbackPolling: true });
+                },
+                changes: emptyArray
+            });
+
+            verifyTscWatch({
+                scenario,
+                subScenario: "watchExtends/with watchFile as watch options to extend",
+                commandLineArgs: ["-w", "-p", "/a/b/tsconfig.json", "--watchFile", "UseFsEvents"],
+                sys: () => {
+                    const extendedFile: File = {
+                        path: "/a/b/extended.tsconfig.json",
+                        content: "{}"
+                    };
+                    const configFile: File = {
+                        path: "/a/b/tsconfig.json",
+                        content: JSON.stringify({
+                            extends: "./extended.tsconfig.json"
+                        })
+                    };
+                    const files = [libFile, commonFile1, commonFile2, extendedFile, configFile];
+                    return createWatchedSystem(files);
+                },
+                changes: emptyArray
+            });
+        });
     });
 }

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchExtends/with-fallbackPolling-option.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchExtends/with-fallbackPolling-option.js
@@ -1,0 +1,79 @@
+Input::
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+//// [/a/b/commonFile1.ts]
+let x = 1
+
+//// [/a/b/commonFile2.ts]
+let y = 1
+
+//// [/a/b/extended.tsconfig.json]
+{"watchOptions":{"fallbackPolling":"PriorityInterval"}}
+
+//// [/a/b/tsconfig.json]
+{"extends":"./extended.tsconfig.json"}
+
+
+/a/lib/tsc.js -w -p /a/b/tsconfig.json
+Output::
+>> Screen clear
+[[90m12:00:19 AM[0m] Starting compilation in watch mode...
+
+[[90m12:00:24 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+Program root files: ["/a/b/commonFile1.ts","/a/b/commonFile2.ts"]
+Program options: {"watch":true,"project":"/a/b/tsconfig.json","configFilePath":"/a/b/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/a/b/commonFile1.ts
+/a/b/commonFile2.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/a/b/commonFile1.ts
+/a/b/commonFile2.ts
+
+WatchedFiles::
+/a/b/tsconfig.json:
+  {"fileName":"/a/b/tsconfig.json","pollingInterval":250}
+/a/b/commonfile1.ts:
+  {"fileName":"/a/b/commonFile1.ts","pollingInterval":250}
+/a/b/commonfile2.ts:
+  {"fileName":"/a/b/commonFile2.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/a/b/extended.tsconfig.json:
+  {"fileName":"/a/b/extended.tsconfig.json","pollingInterval":250}
+/a/b/node_modules/@types:
+  {"fileName":"/a/b/node_modules/@types","pollingInterval":500}
+/a/b:
+  {"fileName":"/a/b","pollingInterval":500}
+
+FsWatches::
+
+FsWatchesRecursive::
+
+exitCode:: ExitStatus.undefined
+
+//// [/a/b/commonFile1.js]
+var x = 1;
+
+
+//// [/a/b/commonFile2.js]
+var y = 1;
+
+

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchExtends/with-watchDirectory-option.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchExtends/with-watchDirectory-option.js
@@ -1,0 +1,79 @@
+Input::
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+//// [/a/b/commonFile1.ts]
+let x = 1
+
+//// [/a/b/commonFile2.ts]
+let y = 1
+
+//// [/a/b/extended.tsconfig.json]
+{"watchOptions":{"watchDirectory":"UseFsEvents"}}
+
+//// [/a/b/tsconfig.json]
+{"extends":"./extended.tsconfig.json"}
+
+
+/a/lib/tsc.js -w -p /a/b/tsconfig.json
+Output::
+>> Screen clear
+[[90m12:00:19 AM[0m] Starting compilation in watch mode...
+
+[[90m12:00:24 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+Program root files: ["/a/b/commonFile1.ts","/a/b/commonFile2.ts"]
+Program options: {"watch":true,"project":"/a/b/tsconfig.json","configFilePath":"/a/b/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/a/b/commonFile1.ts
+/a/b/commonFile2.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/a/b/commonFile1.ts
+/a/b/commonFile2.ts
+
+WatchedFiles::
+/a/b/tsconfig.json:
+  {"fileName":"/a/b/tsconfig.json","pollingInterval":250}
+/a/b/commonfile1.ts:
+  {"fileName":"/a/b/commonFile1.ts","pollingInterval":250}
+/a/b/commonfile2.ts:
+  {"fileName":"/a/b/commonFile2.ts","pollingInterval":250}
+/a/lib/lib.d.ts:
+  {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
+/a/b/extended.tsconfig.json:
+  {"fileName":"/a/b/extended.tsconfig.json","pollingInterval":250}
+
+FsWatches::
+/a/b/node_modules/@types:
+  {"directoryName":"/a/b/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/a/b:
+  {"directoryName":"/a/b","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+FsWatchesRecursive::
+
+exitCode:: ExitStatus.undefined
+
+//// [/a/b/commonFile1.js]
+var x = 1;
+
+
+//// [/a/b/commonFile2.js]
+var y = 1;
+
+

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchExtends/with-watchFile-as-watch-options-to-extend.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchExtends/with-watchFile-as-watch-options-to-extend.js
@@ -1,0 +1,79 @@
+Input::
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+//// [/a/b/commonFile1.ts]
+let x = 1
+
+//// [/a/b/commonFile2.ts]
+let y = 1
+
+//// [/a/b/extended.tsconfig.json]
+{}
+
+//// [/a/b/tsconfig.json]
+{"extends":"./extended.tsconfig.json"}
+
+
+/a/lib/tsc.js -w -p /a/b/tsconfig.json --watchFile UseFsEvents
+Output::
+>> Screen clear
+[[90m12:00:19 AM[0m] Starting compilation in watch mode...
+
+[[90m12:00:24 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+Program root files: ["/a/b/commonFile1.ts","/a/b/commonFile2.ts"]
+Program options: {"watch":true,"project":"/a/b/tsconfig.json","configFilePath":"/a/b/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/a/b/commonFile1.ts
+/a/b/commonFile2.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/a/b/commonFile1.ts
+/a/b/commonFile2.ts
+
+WatchedFiles::
+
+FsWatches::
+/a/b/tsconfig.json:
+  {"directoryName":"/a/b/tsconfig.json","fallbackPollingInterval":2000,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/a/b/commonfile1.ts:
+  {"directoryName":"/a/b/commonFile1.ts","fallbackPollingInterval":250,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/a/b/commonfile2.ts:
+  {"directoryName":"/a/b/commonFile2.ts","fallbackPollingInterval":250,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/a/lib/lib.d.ts:
+  {"directoryName":"/a/lib/lib.d.ts","fallbackPollingInterval":250,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/a/b/extended.tsconfig.json:
+  {"directoryName":"/a/b/extended.tsconfig.json","fallbackPollingInterval":2000,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+FsWatchesRecursive::
+/a/b/node_modules/@types:
+  {"directoryName":"/a/b/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/a/b:
+  {"directoryName":"/a/b","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/a/b/commonFile1.js]
+var x = 1;
+
+
+//// [/a/b/commonFile2.js]
+var y = 1;
+
+

--- a/tests/baselines/reference/tscWatch/watchEnvironment/watchExtends/with-watchFile-option.js
+++ b/tests/baselines/reference/tscWatch/watchEnvironment/watchExtends/with-watchFile-option.js
@@ -1,0 +1,79 @@
+Input::
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+//// [/a/b/commonFile1.ts]
+let x = 1
+
+//// [/a/b/commonFile2.ts]
+let y = 1
+
+//// [/a/b/extended.tsconfig.json]
+{"watchOptions":{"watchFile":"UseFsEvents"}}
+
+//// [/a/b/tsconfig.json]
+{"extends":"./extended.tsconfig.json"}
+
+
+/a/lib/tsc.js -w -p /a/b/tsconfig.json
+Output::
+>> Screen clear
+[[90m12:00:19 AM[0m] Starting compilation in watch mode...
+
+[[90m12:00:24 AM[0m] Found 0 errors. Watching for file changes.
+
+
+
+Program root files: ["/a/b/commonFile1.ts","/a/b/commonFile2.ts"]
+Program options: {"watch":true,"project":"/a/b/tsconfig.json","configFilePath":"/a/b/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/a/b/commonFile1.ts
+/a/b/commonFile2.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/a/b/commonFile1.ts
+/a/b/commonFile2.ts
+
+WatchedFiles::
+
+FsWatches::
+/a/b/tsconfig.json:
+  {"directoryName":"/a/b/tsconfig.json","fallbackPollingInterval":2000,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/a/b/commonfile1.ts:
+  {"directoryName":"/a/b/commonFile1.ts","fallbackPollingInterval":250,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/a/b/commonfile2.ts:
+  {"directoryName":"/a/b/commonFile2.ts","fallbackPollingInterval":250,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/a/lib/lib.d.ts:
+  {"directoryName":"/a/lib/lib.d.ts","fallbackPollingInterval":250,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/a/b/extended.tsconfig.json:
+  {"directoryName":"/a/b/extended.tsconfig.json","fallbackPollingInterval":2000,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+FsWatchesRecursive::
+/a/b/node_modules/@types:
+  {"directoryName":"/a/b/node_modules/@types","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+/a/b:
+  {"directoryName":"/a/b","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
+
+exitCode:: ExitStatus.undefined
+
+//// [/a/b/commonFile1.js]
+var x = 1;
+
+
+//// [/a/b/commonFile2.js]
+var y = 1;
+
+


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes one-seven-seven-five-three (to prevent linking back to the issue for now)

Inspects `extendedSourceFiles` from `configFile` in `CompilerOptions` and starts watcher for each file. Watch callback invokes `scheduleProgramReload` just like the watcher for the main config file. Watcher pattern modelled after watcher map for missing files.

Added new test cases, copied from `watchEnvironment/watchOptions` that adds an extended config to verify it is being watched.