### PR TITLE
Gh 41788 incorrect output for esprivate with nested class in esnext

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26351,17 +26351,17 @@ namespace ts {
             if (isPrivateIdentifier(right)) {
                 const lexicallyScopedSymbol = lookupSymbolForPrivateIdentifierDeclaration(right.escapedText, right);
 
-                if(lexicallyScopedSymbol && (compilerOptions.target === ScriptTarget.ESNext && compilerOptions.useDefineForClassFields === false)) {
+                if (lexicallyScopedSymbol && (compilerOptions.target === ScriptTarget.ESNext && !useDefineForClassFields)) {
                     const lexicalValueDecl = lexicallyScopedSymbol.valueDeclaration;
                     const lexicalClass = getContainingClass(lexicalValueDecl);
                     const parentStaticFieldInitializer = findAncestor(node, (n) => {
-                        if(n === lexicalClass) return "quit";
-                        if(isPropertyDeclaration(n.parent) && n.parent.initializer === n && n.parent.parent === lexicalClass) {
+                        if (n === lexicalClass) return "quit";
+                        if (isPropertyDeclaration(n.parent) && n.parent.initializer === n && n.parent.parent === lexicalClass) {
                             return true;
                         }
                         return false;
                     });
-                    if(parentStaticFieldInitializer) {
+                    if (parentStaticFieldInitializer) {
                         const parentStaticFieldInitializerSymbol = getSymbolOfNode(parentStaticFieldInitializer.parent);
                         Debug.assert(parentStaticFieldInitializerSymbol, "Initializer without declaration symbol");
                         const diagnostic = error(node,

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26350,6 +26350,31 @@ namespace ts {
             let prop: Symbol | undefined;
             if (isPrivateIdentifier(right)) {
                 const lexicallyScopedSymbol = lookupSymbolForPrivateIdentifierDeclaration(right.escapedText, right);
+
+                if(lexicallyScopedSymbol && (compilerOptions.target === ScriptTarget.ESNext && compilerOptions.useDefineForClassFields === false)) {
+                    const lexicalValueDecl = lexicallyScopedSymbol.valueDeclaration;
+                    const lexicalClass = getContainingClass(lexicalValueDecl);
+                    const parentStaticFieldInitializer = findAncestor(node, (n) => {
+                        if(n == lexicalClass) return "quit";
+                        if(isPropertyDeclaration(n.parent) && n.parent.initializer == n && n.parent.parent === lexicalClass) {
+                            return true;
+                        }
+                        return false;
+                    });
+                    if(parentStaticFieldInitializer) {
+                        const parentStaticFieldInitializerSymbol = getSymbolOfNode(parentStaticFieldInitializer.parent);
+                        Debug.assert(parentStaticFieldInitializerSymbol, "Initializer without declaration symbol");
+                        const diagnostic = error(node,
+                            Diagnostics.Property_0_has_a_private_name_but_is_used_in_a_static_initializer_in_its_declaring_class_This_is_only_supported_for_an_ESNext_target_if_useDefineForClassFields_is_set_to_true,
+                            symbolName(lexicallyScopedSymbol));
+                        addRelatedInfo(diagnostic,
+                            createDiagnosticForNode(parentStaticFieldInitializer.parent,
+                                Diagnostics.Initializer_for_property_0,
+                                symbolName(parentStaticFieldInitializerSymbol))
+                        );
+                    }
+                }
+
                 if (isAnyLike) {
                     if (lexicallyScopedSymbol) {
                         return apparentType;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26355,8 +26355,8 @@ namespace ts {
                     const lexicalValueDecl = lexicallyScopedSymbol.valueDeclaration;
                     const lexicalClass = getContainingClass(lexicalValueDecl);
                     const parentStaticFieldInitializer = findAncestor(node, (n) => {
-                        if(n == lexicalClass) return "quit";
-                        if(isPropertyDeclaration(n.parent) && n.parent.initializer == n && n.parent.parent === lexicalClass) {
+                        if(n === lexicalClass) return "quit";
+                        if(isPropertyDeclaration(n.parent) && n.parent.initializer === n && n.parent.parent === lexicalClass) {
                             return true;
                         }
                         return false;

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3256,6 +3256,14 @@
         "category": "Error",
         "code": 2800
     },
+    "Property '{0}' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'": {
+        "category": "Error",
+        "code": 2801
+    },
+    "Initializer for property '{0}'": {
+        "category": "Error",
+        "code": 2802
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/src/compiler/transformers/classFields.ts
+++ b/src/compiler/transformers/classFields.ts
@@ -41,6 +41,7 @@ namespace ts {
         const resolver = context.getEmitResolver();
         const compilerOptions = context.getCompilerOptions();
         const languageVersion = getEmitScriptTarget(compilerOptions);
+        const useDefineForClassFields = getUseDefineForClassFields(compilerOptions);
 
         const shouldTransformPrivateFields = languageVersion < ScriptTarget.ESNext;
 
@@ -71,7 +72,7 @@ namespace ts {
         function transformSourceFile(node: SourceFile) {
             const options = context.getCompilerOptions();
             if (node.isDeclarationFile
-                || options.useDefineForClassFields && options.target === ScriptTarget.ESNext) {
+                || useDefineForClassFields && options.target === ScriptTarget.ESNext) {
                 return node;
             }
             const visited = visitEachChild(node, visitor, context);
@@ -209,7 +210,7 @@ namespace ts {
             // Create a temporary variable to store a computed property name (if necessary).
             // If it's not inlineable, then we emit an expression after the class which assigns
             // the property name to the temporary variable.
-            const expr = getPropertyNameExpressionIfNeeded(node.name, !!node.initializer || !!context.getCompilerOptions().useDefineForClassFields);
+            const expr = getPropertyNameExpressionIfNeeded(node.name, !!node.initializer || useDefineForClassFields);
             if (expr && !isSimpleInlineableExpression(expr)) {
                 getPendingExpressions().push(expr);
             }
@@ -589,7 +590,7 @@ namespace ts {
             if (!isPropertyDeclaration(member) || hasStaticModifier(member) || hasSyntacticModifier(getOriginalNode(member), ModifierFlags.Abstract)) {
                 return false;
             }
-            if (context.getCompilerOptions().useDefineForClassFields) {
+            if (useDefineForClassFields) {
                 // If we are using define semantics and targeting ESNext or higher,
                 // then we don't need to transform any class properties.
                 return languageVersion < ScriptTarget.ESNext;
@@ -625,7 +626,6 @@ namespace ts {
         }
 
         function transformConstructorBody(node: ClassDeclaration | ClassExpression, constructor: ConstructorDeclaration | undefined, isDerivedClass: boolean) {
-            const useDefineForClassFields = context.getCompilerOptions().useDefineForClassFields;
             let properties = getProperties(node, /*requireInitializer*/ false, /*isStatic*/ false);
             if (!useDefineForClassFields) {
                 properties = filter(properties, property => !!property.initializer || isPrivateIdentifier(property.name));
@@ -755,7 +755,7 @@ namespace ts {
          */
         function transformProperty(property: PropertyDeclaration, receiver: LeftHandSideExpression) {
             // We generate a name here in order to reuse the value cached by the relocated computed name expression (which uses the same generated name)
-            const emitAssignment = !context.getCompilerOptions().useDefineForClassFields;
+            const emitAssignment = !useDefineForClassFields;
             const propertyName = isComputedPropertyName(property.name) && !isSimpleInlineableExpression(property.name.expression)
                 ? factory.updateComputedPropertyName(property.name, factory.getGeneratedNameForNode(property.name))
                 : property.name;

--- a/src/compiler/transformers/es2015.ts
+++ b/src/compiler/transformers/es2015.ts
@@ -1626,7 +1626,7 @@ namespace ts {
             const memberFunction = transformFunctionLikeToExpression(member, /*location*/ member, /*name*/ undefined, container);
             const propertyName = visitNode(member.name, visitor, isPropertyName);
             let e: Expression;
-            if (!isPrivateIdentifier(propertyName) && context.getCompilerOptions().useDefineForClassFields) {
+            if (!isPrivateIdentifier(propertyName) && getUseDefineForClassFields(context.getCompilerOptions())) {
                 const name = isComputedPropertyName(propertyName) ? propertyName.expression
                     : isIdentifier(propertyName) ? factory.createStringLiteral(unescapeLeadingUnderscores(propertyName.escapedText))
                     : propertyName;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -6045,6 +6045,10 @@ namespace ts {
         return compilerOptions.allowJs === undefined ? !!compilerOptions.checkJs : compilerOptions.allowJs;
     }
 
+    export function getUseDefineForClassFields(compilerOptions: CompilerOptions): boolean {
+        return compilerOptions.useDefineForClassFields === undefined ? compilerOptions.target === ScriptTarget.ESNext : compilerOptions.useDefineForClassFields;
+    }
+
     export function compilerOptionsAffectSemanticDiagnostics(newOptions: CompilerOptions, oldOptions: CompilerOptions): boolean {
         return oldOptions !== newOptions &&
             semanticDiagnosticsOptionDeclarations.some(option => !isJsonEqual(getCompilerOptionValue(oldOptions, option), getCompilerOptionValue(newOptions, option)));

--- a/src/testRunner/unittests/transform.ts
+++ b/src/testRunner/unittests/transform.ts
@@ -176,6 +176,7 @@ namespace ts {
                 compilerOptions: {
                     target: ScriptTarget.ESNext,
                     newLine: NewLineKind.CarriageReturnLineFeed,
+                    useDefineForClassFields: false,
                 }
             }).outputText;
         });

--- a/tests/baselines/reference/classWithStaticFieldInParameterBindingPattern(target=esnext).js
+++ b/tests/baselines/reference/classWithStaticFieldInParameterBindingPattern(target=esnext).js
@@ -4,7 +4,6 @@
 
 //// [classWithStaticFieldInParameterBindingPattern.js]
 // https://github.com/microsoft/TypeScript/issues/36295
-((_a) => { var _b; var { [(_b = class {
-    },
-    _b.x = 1,
-    _b).x]: b = "" } = _a; })();
+(({ [class {
+    static x = 1;
+}.x]: b = "" }) => { })();

--- a/tests/baselines/reference/classWithStaticFieldInParameterInitializer(target=esnext).js
+++ b/tests/baselines/reference/classWithStaticFieldInParameterInitializer(target=esnext).js
@@ -4,7 +4,6 @@
 
 //// [classWithStaticFieldInParameterInitializer.js]
 // https://github.com/microsoft/TypeScript/issues/36295
-((b) => { var _a; if (b === void 0) { b = (_a = class {
-    },
-    _a.x = 1,
-    _a); } })();
+((b = class {
+    static x = 1;
+}) => { })();

--- a/tests/baselines/reference/privateNameAndStaticInitializer(target=esnext).js
+++ b/tests/baselines/reference/privateNameAndStaticInitializer(target=esnext).js
@@ -9,11 +9,7 @@ class A {
 
 //// [privateNameAndStaticInitializer.js]
 class A {
-    constructor() {
-        this.#foo = 1;
-        this.#prop = 2;
-    }
-    #foo;
-    #prop;
+    #foo = 1;
+    static inst = new A();
+    #prop = 2;
 }
-A.inst = new A();

--- a/tests/baselines/reference/privateNameComputedPropertyName1(target=esnext).js
+++ b/tests/baselines/reference/privateNameComputedPropertyName1(target=esnext).js
@@ -39,18 +39,15 @@ new A().test();
 
 //// [privateNameComputedPropertyName1.js]
 class A {
+    #a = 'a';
+    #b;
+    #c = 'c';
+    #d;
+    #e = '';
     constructor() {
-        this.#a = 'a';
-        this.#c = 'c';
-        this.#e = '';
         this.#b = 'b';
         this.#d = 'd';
     }
-    #a;
-    #b;
-    #c;
-    #d;
-    #e;
     test() {
         const data = { a: 'a', b: 'b', c: 'c', d: 'd', e: 'e' };
         const { [this.#a]: a, [this.#b]: b, [this.#c]: c, [this.#d]: d, [this.#e = 'e']: e, } = data;

--- a/tests/baselines/reference/privateNameComputedPropertyName2(target=esnext).js
+++ b/tests/baselines/reference/privateNameComputedPropertyName2(target=esnext).js
@@ -12,10 +12,7 @@ console.log(getX(new A));
 //// [privateNameComputedPropertyName2.js]
 let getX;
 class A {
-    constructor() {
-        this.#x = 100;
-    }
-    #x;
+    #x = 100;
     [(getX = (a) => a.#x, "_")]() { }
 }
 console.log(getX(new A));

--- a/tests/baselines/reference/privateNameComputedPropertyName3(target=esnext).js
+++ b/tests/baselines/reference/privateNameComputedPropertyName3(target=esnext).js
@@ -26,17 +26,14 @@ console.log(new Foo("NAME").getValue(100));
 
 //// [privateNameComputedPropertyName3.js]
 class Foo {
+    #name;
     constructor(name) {
         this.#name = name;
     }
-    #name;
     getValue(x) {
         const obj = this;
         class Bar {
-            constructor() {
-                this.#y = 100;
-            }
-            #y;
+            #y = 100;
             [obj.#name]() {
                 return x + this.#y;
             }

--- a/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=es2020).js
+++ b/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=es2020).js
@@ -1,0 +1,67 @@
+//// [privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts]
+class Test {
+    #prop = 0 
+    static dd = new Test().#prop; // Err
+    static ["X_ z_ zz"] = class Inner {
+        #foo  = 10   
+        m() {
+            new Test().#prop // Err
+        }
+        static C = class InnerInner {
+            m() {
+                new Test().#prop // Err
+                new Inner().#foo; // Err
+            }
+        }
+
+        static M(){
+            return class {
+                m() {
+                    new Test().#prop // Err
+                    new Inner().#foo; // OK
+                }
+            }
+        } 
+    }
+}
+
+//// [privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.js]
+"use strict";
+var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (receiver, privateMap) {
+    if (!privateMap.has(receiver)) {
+        throw new TypeError("attempted to get private field on non-instance");
+    }
+    return privateMap.get(receiver);
+};
+var _prop, _foo, _a;
+class Test {
+    constructor() {
+        _prop.set(this, 0);
+    }
+}
+_prop = new WeakMap();
+Test.dd = __classPrivateFieldGet(new Test(), _prop); // Err
+Test["X_ z_ zz"] = (_a = class Inner {
+        constructor() {
+            _foo.set(this, 10);
+        }
+        m() {
+            __classPrivateFieldGet(new Test(), _prop); // Err
+        }
+        static M() {
+            return class {
+                m() {
+                    __classPrivateFieldGet(new Test(), _prop); // Err
+                    __classPrivateFieldGet(new Inner(), _foo); // OK
+                }
+            };
+        }
+    },
+    _foo = new WeakMap(),
+    _a.C = class InnerInner {
+        m() {
+            __classPrivateFieldGet(new Test(), _prop); // Err
+            __classPrivateFieldGet(new _a(), _foo); // Err
+        }
+    },
+    _a);

--- a/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=es2020).symbols
+++ b/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=es2020).symbols
@@ -1,0 +1,63 @@
+=== tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts ===
+class Test {
+>Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+
+    #prop = 0 
+>#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
+
+    static dd = new Test().#prop; // Err
+>dd : Symbol(Test.dd, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 1, 13))
+>new Test().#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
+>Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+
+    static ["X_ z_ zz"] = class Inner {
+>["X_ z_ zz"] : Symbol(Test["X_ z_ zz"], Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 2, 33))
+>"X_ z_ zz" : Symbol(Test["X_ z_ zz"], Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 2, 33))
+>Inner : Symbol(Inner, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 25))
+
+        #foo  = 10   
+>#foo : Symbol(Inner.#foo, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 39))
+
+        m() {
+>m : Symbol(Inner.m, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 4, 18))
+
+            new Test().#prop // Err
+>new Test().#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
+>Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+        }
+        static C = class InnerInner {
+>C : Symbol(Inner.C, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 7, 9))
+>InnerInner : Symbol(InnerInner, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 8, 18))
+
+            m() {
+>m : Symbol(InnerInner.m, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 8, 37))
+
+                new Test().#prop // Err
+>new Test().#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
+>Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+
+                new Inner().#foo; // Err
+>new Inner().#foo : Symbol(Inner.#foo, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 39))
+>Inner : Symbol(Inner, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 25))
+            }
+        }
+
+        static M(){
+>M : Symbol(Inner.M, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 13, 9))
+
+            return class {
+                m() {
+>m : Symbol((Anonymous class).m, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 16, 26))
+
+                    new Test().#prop // Err
+>new Test().#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
+>Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+
+                    new Inner().#foo; // OK
+>new Inner().#foo : Symbol(Inner.#foo, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 39))
+>Inner : Symbol(Inner, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 25))
+                }
+            }
+        } 
+    }
+}

--- a/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=es2020).types
+++ b/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=es2020).types
@@ -1,0 +1,75 @@
+=== tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts ===
+class Test {
+>Test : Test
+
+    #prop = 0 
+>#prop : number
+>0 : 0
+
+    static dd = new Test().#prop; // Err
+>dd : number
+>new Test().#prop : number
+>new Test() : Test
+>Test : typeof Test
+
+    static ["X_ z_ zz"] = class Inner {
+>["X_ z_ zz"] : typeof Inner
+>"X_ z_ zz" : "X_ z_ zz"
+>class Inner {        #foo  = 10           m() {            new Test().#prop // Err        }        static C = class InnerInner {            m() {                new Test().#prop // Err                new Inner().#foo; // Err            }        }        static M(){            return class {                m() {                    new Test().#prop // Err                    new Inner().#foo; // OK                }            }        }     } : typeof Inner
+>Inner : typeof Inner
+
+        #foo  = 10   
+>#foo : number
+>10 : 10
+
+        m() {
+>m : () => void
+
+            new Test().#prop // Err
+>new Test().#prop : number
+>new Test() : Test
+>Test : typeof Test
+        }
+        static C = class InnerInner {
+>C : typeof InnerInner
+>class InnerInner {            m() {                new Test().#prop // Err                new Inner().#foo; // Err            }        } : typeof InnerInner
+>InnerInner : typeof InnerInner
+
+            m() {
+>m : () => void
+
+                new Test().#prop // Err
+>new Test().#prop : number
+>new Test() : Test
+>Test : typeof Test
+
+                new Inner().#foo; // Err
+>new Inner().#foo : number
+>new Inner() : Inner
+>Inner : typeof Inner
+            }
+        }
+
+        static M(){
+>M : () => typeof (Anonymous class)
+
+            return class {
+>class {                m() {                    new Test().#prop // Err                    new Inner().#foo; // OK                }            } : typeof (Anonymous class)
+
+                m() {
+>m : () => void
+
+                    new Test().#prop // Err
+>new Test().#prop : number
+>new Test() : Test
+>Test : typeof Test
+
+                    new Inner().#foo; // OK
+>new Inner().#foo : number
+>new Inner() : Inner
+>Inner : typeof Inner
+                }
+            }
+        } 
+    }
+}

--- a/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=esnext).errors.txt
+++ b/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=esnext).errors.txt
@@ -1,0 +1,48 @@
+tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(3,17): error TS2801: Property '#prop' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
+tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(7,13): error TS2801: Property '#prop' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
+tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(11,17): error TS2801: Property '#prop' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
+tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(12,17): error TS2801: Property '#foo' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
+tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts(19,21): error TS2801: Property '#prop' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
+
+
+==== tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts (5 errors) ====
+    class Test {
+        #prop = 0 
+        static dd = new Test().#prop; // Err
+                    ~~~~~~~~~~~~~~~~
+!!! error TS2801: Property '#prop' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
+!!! related TS2802 tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts:3:12: Initializer for property 'dd'
+        static ["X_ z_ zz"] = class Inner {
+            #foo  = 10   
+            m() {
+                new Test().#prop // Err
+                ~~~~~~~~~~~~~~~~
+!!! error TS2801: Property '#prop' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
+!!! related TS2802 tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts:4:12: Initializer for property 'X_ z_ zz'
+            }
+            static C = class InnerInner {
+                m() {
+                    new Test().#prop // Err
+                    ~~~~~~~~~~~~~~~~
+!!! error TS2801: Property '#prop' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
+!!! related TS2802 tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts:4:12: Initializer for property 'X_ z_ zz'
+                    new Inner().#foo; // Err
+                    ~~~~~~~~~~~~~~~~
+!!! error TS2801: Property '#foo' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
+!!! related TS2802 tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts:9:16: Initializer for property 'C'
+                }
+            }
+    
+            static M(){
+                return class {
+                    m() {
+                        new Test().#prop // Err
+                        ~~~~~~~~~~~~~~~~
+!!! error TS2801: Property '#prop' has a private name but is used in a static initializer in its declaring class. This is only supported for an ESNext target if 'useDefineForClassFields' is set to 'true'
+!!! related TS2802 tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts:4:12: Initializer for property 'X_ z_ zz'
+                        new Inner().#foo; // OK
+                    }
+                }
+            } 
+        }
+    }

--- a/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=esnext).js
+++ b/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=esnext).js
@@ -1,0 +1,61 @@
+//// [privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts]
+class Test {
+    #prop = 0 
+    static dd = new Test().#prop; // Err
+    static ["X_ z_ zz"] = class Inner {
+        #foo  = 10   
+        m() {
+            new Test().#prop // Err
+        }
+        static C = class InnerInner {
+            m() {
+                new Test().#prop // Err
+                new Inner().#foo; // Err
+            }
+        }
+
+        static M(){
+            return class {
+                m() {
+                    new Test().#prop // Err
+                    new Inner().#foo; // OK
+                }
+            }
+        } 
+    }
+}
+
+//// [privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.js]
+"use strict";
+var _a;
+class Test {
+    constructor() {
+        this.#prop = 0;
+    }
+    #prop;
+}
+Test.dd = new Test().#prop; // Err
+Test["X_ z_ zz"] = (_a = class Inner {
+        constructor() {
+            this.#foo = 10;
+        }
+        #foo;
+        m() {
+            new Test().#prop; // Err
+        }
+        static M() {
+            return class {
+                m() {
+                    new Test().#prop; // Err
+                    new Inner().#foo; // OK
+                }
+            };
+        }
+    },
+    _a.C = class InnerInner {
+        m() {
+            new Test().#prop; // Err
+            new _a().#foo; // Err
+        }
+    },
+    _a);

--- a/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=esnext).symbols
+++ b/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=esnext).symbols
@@ -1,0 +1,63 @@
+=== tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts ===
+class Test {
+>Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+
+    #prop = 0 
+>#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
+
+    static dd = new Test().#prop; // Err
+>dd : Symbol(Test.dd, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 1, 13))
+>new Test().#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
+>Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+
+    static ["X_ z_ zz"] = class Inner {
+>["X_ z_ zz"] : Symbol(Test["X_ z_ zz"], Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 2, 33))
+>"X_ z_ zz" : Symbol(Test["X_ z_ zz"], Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 2, 33))
+>Inner : Symbol(Inner, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 25))
+
+        #foo  = 10   
+>#foo : Symbol(Inner.#foo, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 39))
+
+        m() {
+>m : Symbol(Inner.m, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 4, 18))
+
+            new Test().#prop // Err
+>new Test().#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
+>Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+        }
+        static C = class InnerInner {
+>C : Symbol(Inner.C, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 7, 9))
+>InnerInner : Symbol(InnerInner, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 8, 18))
+
+            m() {
+>m : Symbol(InnerInner.m, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 8, 37))
+
+                new Test().#prop // Err
+>new Test().#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
+>Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+
+                new Inner().#foo; // Err
+>new Inner().#foo : Symbol(Inner.#foo, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 39))
+>Inner : Symbol(Inner, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 25))
+            }
+        }
+
+        static M(){
+>M : Symbol(Inner.M, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 13, 9))
+
+            return class {
+                m() {
+>m : Symbol((Anonymous class).m, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 16, 26))
+
+                    new Test().#prop // Err
+>new Test().#prop : Symbol(Test.#prop, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 12))
+>Test : Symbol(Test, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 0, 0))
+
+                    new Inner().#foo; // OK
+>new Inner().#foo : Symbol(Inner.#foo, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 39))
+>Inner : Symbol(Inner, Decl(privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts, 3, 25))
+                }
+            }
+        } 
+    }
+}

--- a/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=esnext).types
+++ b/tests/baselines/reference/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext(target=esnext).types
@@ -1,0 +1,75 @@
+=== tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts ===
+class Test {
+>Test : Test
+
+    #prop = 0 
+>#prop : number
+>0 : 0
+
+    static dd = new Test().#prop; // Err
+>dd : number
+>new Test().#prop : number
+>new Test() : Test
+>Test : typeof Test
+
+    static ["X_ z_ zz"] = class Inner {
+>["X_ z_ zz"] : typeof Inner
+>"X_ z_ zz" : "X_ z_ zz"
+>class Inner {        #foo  = 10           m() {            new Test().#prop // Err        }        static C = class InnerInner {            m() {                new Test().#prop // Err                new Inner().#foo; // Err            }        }        static M(){            return class {                m() {                    new Test().#prop // Err                    new Inner().#foo; // OK                }            }        }     } : typeof Inner
+>Inner : typeof Inner
+
+        #foo  = 10   
+>#foo : number
+>10 : 10
+
+        m() {
+>m : () => void
+
+            new Test().#prop // Err
+>new Test().#prop : number
+>new Test() : Test
+>Test : typeof Test
+        }
+        static C = class InnerInner {
+>C : typeof InnerInner
+>class InnerInner {            m() {                new Test().#prop // Err                new Inner().#foo; // Err            }        } : typeof InnerInner
+>InnerInner : typeof InnerInner
+
+            m() {
+>m : () => void
+
+                new Test().#prop // Err
+>new Test().#prop : number
+>new Test() : Test
+>Test : typeof Test
+
+                new Inner().#foo; // Err
+>new Inner().#foo : number
+>new Inner() : Inner
+>Inner : typeof Inner
+            }
+        }
+
+        static M(){
+>M : () => typeof (Anonymous class)
+
+            return class {
+>class {                m() {                    new Test().#prop // Err                    new Inner().#foo; // OK                }            } : typeof (Anonymous class)
+
+                m() {
+>m : () => void
+
+                    new Test().#prop // Err
+>new Test().#prop : number
+>new Test() : Test
+>Test : typeof Test
+
+                    new Inner().#foo; // OK
+>new Inner().#foo : number
+>new Inner() : Inner
+>Inner : typeof Inner
+                }
+            }
+        } 
+    }
+}

--- a/tests/baselines/reference/privateNameFieldDestructuredBinding(target=esnext).js
+++ b/tests/baselines/reference/privateNameFieldDestructuredBinding(target=esnext).js
@@ -26,9 +26,15 @@ class A {
 
 //// [privateNameFieldDestructuredBinding.js]
 class A {
+    #field = 1;
+    otherObject = new A();
+    testObject() {
+        return { x: 10, y: 6 };
+    }
+    testArray() {
+        return [10, 11];
+    }
     constructor() {
-        this.#field = 1;
-        this.otherObject = new A();
         let y;
         ({ x: this.#field, y } = this.testObject());
         ([this.#field, y] = this.testArray());
@@ -37,13 +43,6 @@ class A {
         ({ a: this.#field = 1, b: [this.#field = 1] } = { b: [] });
         [this.#field = 2] = [];
         [this.otherObject.#field = 2] = [];
-    }
-    #field;
-    testObject() {
-        return { x: 10, y: 6 };
-    }
-    testArray() {
-        return [10, 11];
     }
     static test(_a) {
         [_a.#field] = [2];

--- a/tests/baselines/reference/useDefineForClassFieldsFlagDefault(target=es2020).js
+++ b/tests/baselines/reference/useDefineForClassFieldsFlagDefault(target=es2020).js
@@ -1,0 +1,13 @@
+//// [useDefineForClassFieldsFlagDefault.ts]
+class Foo {
+    // For esNext should be emitted 'as is' because useDefineForClassFields defaults to true 
+    // For es2020 should be emitted as an assignment after the class definition (not Object.defineProperty) because useDefineForClassFields defaults to false
+    static x = 1; 
+}
+
+//// [useDefineForClassFieldsFlagDefault.js]
+class Foo {
+}
+// For esNext should be emitted 'as is' because useDefineForClassFields defaults to true 
+// For es2020 should be emitted as an assignment after the class definition (not Object.defineProperty) because useDefineForClassFields defaults to false
+Foo.x = 1;

--- a/tests/baselines/reference/useDefineForClassFieldsFlagDefault(target=es2020).symbols
+++ b/tests/baselines/reference/useDefineForClassFieldsFlagDefault(target=es2020).symbols
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/useDefineForClassFieldsFlagDefault.ts ===
+class Foo {
+>Foo : Symbol(Foo, Decl(useDefineForClassFieldsFlagDefault.ts, 0, 0))
+
+    // For esNext should be emitted 'as is' because useDefineForClassFields defaults to true 
+    // For es2020 should be emitted as an assignment after the class definition (not Object.defineProperty) because useDefineForClassFields defaults to false
+    static x = 1; 
+>x : Symbol(Foo.x, Decl(useDefineForClassFieldsFlagDefault.ts, 0, 11))
+}

--- a/tests/baselines/reference/useDefineForClassFieldsFlagDefault(target=es2020).types
+++ b/tests/baselines/reference/useDefineForClassFieldsFlagDefault(target=es2020).types
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/useDefineForClassFieldsFlagDefault.ts ===
+class Foo {
+>Foo : Foo
+
+    // For esNext should be emitted 'as is' because useDefineForClassFields defaults to true 
+    // For es2020 should be emitted as an assignment after the class definition (not Object.defineProperty) because useDefineForClassFields defaults to false
+    static x = 1; 
+>x : number
+>1 : 1
+}

--- a/tests/baselines/reference/useDefineForClassFieldsFlagDefault(target=esnext).js
+++ b/tests/baselines/reference/useDefineForClassFieldsFlagDefault(target=esnext).js
@@ -1,0 +1,13 @@
+//// [useDefineForClassFieldsFlagDefault.ts]
+class Foo {
+    // For esNext should be emitted 'as is' because useDefineForClassFields defaults to true 
+    // For es2020 should be emitted as an assignment after the class definition (not Object.defineProperty) because useDefineForClassFields defaults to false
+    static x = 1; 
+}
+
+//// [useDefineForClassFieldsFlagDefault.js]
+class Foo {
+    // For esNext should be emitted 'as is' because useDefineForClassFields defaults to true 
+    // For es2020 should be emitted as an assignment after the class definition (not Object.defineProperty) because useDefineForClassFields defaults to false
+    static x = 1;
+}

--- a/tests/baselines/reference/useDefineForClassFieldsFlagDefault(target=esnext).symbols
+++ b/tests/baselines/reference/useDefineForClassFieldsFlagDefault(target=esnext).symbols
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/useDefineForClassFieldsFlagDefault.ts ===
+class Foo {
+>Foo : Symbol(Foo, Decl(useDefineForClassFieldsFlagDefault.ts, 0, 0))
+
+    // For esNext should be emitted 'as is' because useDefineForClassFields defaults to true 
+    // For es2020 should be emitted as an assignment after the class definition (not Object.defineProperty) because useDefineForClassFields defaults to false
+    static x = 1; 
+>x : Symbol(Foo.x, Decl(useDefineForClassFieldsFlagDefault.ts, 0, 11))
+}

--- a/tests/baselines/reference/useDefineForClassFieldsFlagDefault(target=esnext).types
+++ b/tests/baselines/reference/useDefineForClassFieldsFlagDefault(target=esnext).types
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/useDefineForClassFieldsFlagDefault.ts ===
+class Foo {
+>Foo : Foo
+
+    // For esNext should be emitted 'as is' because useDefineForClassFields defaults to true 
+    // For es2020 should be emitted as an assignment after the class definition (not Object.defineProperty) because useDefineForClassFields defaults to false
+    static x = 1; 
+>x : number
+>1 : 1
+}

--- a/tests/cases/compiler/awaitInClassInAsyncFunction.ts
+++ b/tests/cases/compiler/awaitInClassInAsyncFunction.ts
@@ -1,4 +1,5 @@
 // @target: esnext
+// @useDefineForClassFields: false
 // https://github.com/microsoft/TypeScript/issues/34887
 
 async function bar() {

--- a/tests/cases/compiler/checkSuperCallBeforeThisAccess.ts
+++ b/tests/cases/compiler/checkSuperCallBeforeThisAccess.ts
@@ -1,5 +1,6 @@
 // @strict: true
 // @target: esnext
+// @useDefineForClassFields: false
 
 class A {
     x = 1;

--- a/tests/cases/compiler/classIndexer5.ts
+++ b/tests/cases/compiler/classIndexer5.ts
@@ -1,4 +1,5 @@
 // @target: esnext
+// @useDefineForClassFields: false
 
 class Foo {
     [key: string]: number;

--- a/tests/cases/compiler/controlFlowPrivateClassField.ts
+++ b/tests/cases/compiler/controlFlowPrivateClassField.ts
@@ -1,5 +1,6 @@
 // @strict: true
 // @target: esnext
+// @useDefineForClassFields: false
 class Example {
     #test;
 

--- a/tests/cases/compiler/customAsyncIterator.ts
+++ b/tests/cases/compiler/customAsyncIterator.ts
@@ -1,4 +1,5 @@
 // @target: esnext
+// @useDefineForClassFields: false
 
 // GH: https://github.com/microsoft/TypeScript/issues/33239
 class ConstantIterator<T> implements AsyncIterator<T, undefined, T | undefined> {

--- a/tests/cases/compiler/dynamicNamesErrors.ts
+++ b/tests/cases/compiler/dynamicNamesErrors.ts
@@ -1,6 +1,8 @@
 // @target: esnext
 // @module: commonjs
 // @declaration: true
+// @useDefineForClassFields: false
+
 const c0 = "1";
 const c1 = 1;
 

--- a/tests/cases/compiler/intersectionWithConflictingPrivates.ts
+++ b/tests/cases/compiler/intersectionWithConflictingPrivates.ts
@@ -1,5 +1,6 @@
 // @strict: true
 // @target: esnext
+// @useDefineForClassFields: false
 
 class A { private x: unknown; y?: string; }
 class B { private x: unknown; y?: string; }

--- a/tests/cases/compiler/potentiallyUncalledDecorators.ts
+++ b/tests/cases/compiler/potentiallyUncalledDecorators.ts
@@ -1,6 +1,7 @@
 // @target: esnext
 // @module: esnext
 // @experimentalDecorators: true
+// @useDefineForClassFields: false
 
 // Angular-style Input/Output API:
 declare function Input(bindingPropertyName?: string): any;

--- a/tests/cases/compiler/useDefineForClassFieldsFlagDefault.ts
+++ b/tests/cases/compiler/useDefineForClassFieldsFlagDefault.ts
@@ -1,0 +1,7 @@
+// @target: esNext,es2020
+
+class Foo {
+    // For esNext should be emitted 'as is' because useDefineForClassFields defaults to true 
+    // For es2020 should be emitted as an assignment after the class definition (not Object.defineProperty) because useDefineForClassFields defaults to false
+    static x = 1; 
+}

--- a/tests/cases/conformance/classes/classExpressions/classWithStaticFieldInParameterBindingPattern.2.ts
+++ b/tests/cases/conformance/classes/classExpressions/classWithStaticFieldInParameterBindingPattern.2.ts
@@ -1,6 +1,7 @@
 // @target: esnext,es2015,es5
 // @noTypesAndSymbols: true
 // @noEmit: true
+// @useDefineForClassFields: false
 
 // https://github.com/microsoft/TypeScript/issues/36295
 class C {}

--- a/tests/cases/conformance/classes/classExpressions/classWithStaticFieldInParameterInitializer.2.ts
+++ b/tests/cases/conformance/classes/classExpressions/classWithStaticFieldInParameterInitializer.2.ts
@@ -1,6 +1,7 @@
 // @target: esnext,es2015,es5
 // @noTypesAndSymbols: true
 // @noEmit: true
+// @useDefineForClassFields: false
 
 // https://github.com/microsoft/TypeScript/issues/36295
 class C {}

--- a/tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts
+++ b/tests/cases/conformance/classes/members/privateNames/privateNameErrorsOnNotUseDefineForClassFieldsInEsNext.ts
@@ -1,0 +1,29 @@
+// @strict: true
+// @target: esNext,es2020
+// @useDefineForClassFields: false
+
+class Test {
+    #prop = 0 
+    static dd = new Test().#prop; // Err
+    static ["X_ z_ zz"] = class Inner {
+        #foo  = 10   
+        m() {
+            new Test().#prop // Err
+        }
+        static C = class InnerInner {
+            m() {
+                new Test().#prop // Err
+                new Inner().#foo; // Err
+            }
+        }
+
+        static M(){
+            return class {
+                m() {
+                    new Test().#prop // Err
+                    new Inner().#foo; // OK
+                }
+            }
+        } 
+    }
+}

--- a/tests/cases/conformance/classes/members/privateNames/privateNameFieldsESNext.ts
+++ b/tests/cases/conformance/classes/members/privateNames/privateNameFieldsESNext.ts
@@ -1,4 +1,5 @@
 // @target: esnext
+// @useDefineForClassFields: false
 
 class C {
     a = 123;

--- a/tests/cases/conformance/classes/members/privateNames/privateNamesAndMethods.ts
+++ b/tests/cases/conformance/classes/members/privateNames/privateNamesAndMethods.ts
@@ -1,5 +1,6 @@
 // @target: esnext
 // @lib: esnext
+// @useDefineForClassFields: false
 
 class A {
     #foo(a: number) {}

--- a/tests/cases/conformance/classes/members/privateNames/privateNamesAndStaticMethods.ts
+++ b/tests/cases/conformance/classes/members/privateNames/privateNamesAndStaticMethods.ts
@@ -1,6 +1,7 @@
 // @strict: true
 // @target: esnext
 // @lib: esnext
+// @useDefineForClassFields: false
 
 class A {
     static #foo(a: number) {}

--- a/tests/cases/conformance/classes/members/privateNames/privateNamesAssertion.ts
+++ b/tests/cases/conformance/classes/members/privateNames/privateNamesAssertion.ts
@@ -1,5 +1,6 @@
 // @strict: true
 // @target: esnext
+// @useDefineForClassFields: false
 
 class Foo {
     #p1: (v: any) => asserts v is string = (v) => {

--- a/tests/cases/conformance/classes/propertyMemberDeclarations/overrideInterfaceProperty.ts
+++ b/tests/cases/conformance/classes/propertyMemberDeclarations/overrideInterfaceProperty.ts
@@ -1,4 +1,5 @@
 // @target: esnext
+// @useDefineForClassFields: false
 interface Mup<K, V> {
     readonly size: number;
 }

--- a/tests/cases/conformance/dynamicImport/importCallExpressionInAMD4.ts
+++ b/tests/cases/conformance/dynamicImport/importCallExpressionInAMD4.ts
@@ -1,5 +1,7 @@
 ﻿// @module: amd
 // @target: esnext
+// @useDefineForClassFields: false
+
 // @filename: 0.ts
 export class B {
     print() { return "I am B"}

--- a/tests/cases/conformance/dynamicImport/importCallExpressionInCJS5.ts
+++ b/tests/cases/conformance/dynamicImport/importCallExpressionInCJS5.ts
@@ -1,5 +1,7 @@
 ﻿// @module: commonjs
 // @target: esnext
+// @useDefineForClassFields: false
+
 // @filename: 0.ts
 export class B {
     print() { return "I am B"}

--- a/tests/cases/conformance/dynamicImport/importCallExpressionInSystem4.ts
+++ b/tests/cases/conformance/dynamicImport/importCallExpressionInSystem4.ts
@@ -1,5 +1,7 @@
 ﻿// @module: system
 // @target: esnext
+// @useDefineForClassFields: false
+
 // @filename: 0.ts
 export class B {
     print() { return "I am B"}

--- a/tests/cases/conformance/dynamicImport/importCallExpressionInUMD4.ts
+++ b/tests/cases/conformance/dynamicImport/importCallExpressionInUMD4.ts
@@ -1,5 +1,6 @@
 ﻿// @module: umd
 // @target: esnext
+// @useDefineForClassFields: false
 // @filename: 0.ts
 export class B {
     print() { return "I am B"}

--- a/tests/cases/conformance/es6/templates/taggedTemplatesWithTypeArguments2.ts
+++ b/tests/cases/conformance/es6/templates/taggedTemplatesWithTypeArguments2.ts
@@ -1,5 +1,6 @@
 // @target: esnext
 // @strict: true
+// @useDefineForClassFields: false
 
 export interface SomethingTaggable {
     <T>(t: TemplateStringsArray, ...args: T[]): SomethingNewable;

--- a/tests/cases/conformance/expressions/optionalChaining/privateIdentifierChain/privateIdentifierChain.1.ts
+++ b/tests/cases/conformance/expressions/optionalChaining/privateIdentifierChain/privateIdentifierChain.1.ts
@@ -1,5 +1,6 @@
 // @strict: true
 // @target: esnext
+// @useDefineForClassFields: false
 
 class A {
     a?: A

--- a/tests/cases/conformance/expressions/thisKeyword/typeOfThis.ts
+++ b/tests/cases/conformance/expressions/thisKeyword/typeOfThis.ts
@@ -1,4 +1,5 @@
 // @target: esnext
+// @useDefineForClassFields: false
 class MyTestClass {
     private canary: number;
     static staticCanary: number;

--- a/tests/cases/conformance/externalModules/typeOnly/computedPropertyName.ts
+++ b/tests/cases/conformance/externalModules/typeOnly/computedPropertyName.ts
@@ -1,4 +1,5 @@
 // @target: esnext
+// @useDefineForClassFields: false
 
 // @Filename: framework-hooks.ts
 export const onInit = Symbol("onInit");

--- a/tests/cases/conformance/jsdoc/jsdocReadonlyDeclarations.ts
+++ b/tests/cases/conformance/jsdoc/jsdocReadonlyDeclarations.ts
@@ -4,6 +4,7 @@
 // @out: foo.js
 // @declaration: true
 // @Filename: jsdocReadonlyDeclarations.js
+// @useDefineForClassFields: false
 class C {
     /** @readonly */
     x = 6

--- a/tests/cases/conformance/types/spread/spreadMethods.ts
+++ b/tests/cases/conformance/types/spread/spreadMethods.ts
@@ -1,4 +1,5 @@
 // @target: esnext
+// @useDefineForClassFields: false
 
 class K {
     p = 12;

--- a/tests/cases/conformance/types/uniqueSymbol/uniqueSymbols.ts
+++ b/tests/cases/conformance/types/uniqueSymbol/uniqueSymbols.ts
@@ -1,6 +1,7 @@
 // @target: esnext
 // @lib: esnext
 // @declaration: false
+// @useDefineForClassFields: false
 
 // declarations with call initializer
 const constCall = Symbol();

--- a/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarations.ts
+++ b/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarations.ts
@@ -1,6 +1,7 @@
 // @target: esnext
 // @lib: esnext
 // @declaration: true
+// @useDefineForClassFields: false
 
 // declarations with call initializer
 const constCall = Symbol();

--- a/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsErrors.ts
+++ b/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsErrors.ts
@@ -2,6 +2,7 @@
 // @lib: esnext
 // @module: commonjs
 // @declaration: true
+// @useDefineForClassFields: false
 
 declare const s: unique symbol;
 interface I { readonly readonlyType: unique symbol; }

--- a/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsInJs.ts
+++ b/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsInJs.ts
@@ -5,6 +5,7 @@
 // @checkJs: true
 // @filename: uniqueSymbolsDeclarationsInJs.js
 // @out: uniqueSymbolsDeclarationsInJs-out.js
+// @useDefineForClassFields: false
 
 // classes
 class C {

--- a/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsInJsErrors.ts
+++ b/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsInJsErrors.ts
@@ -5,6 +5,7 @@
 // @checkJs: true
 // @filename: uniqueSymbolsDeclarationsInJsErrors.js
 // @out: uniqueSymbolsDeclarationsInJsErrors-out.js
+// @useDefineForClassFields: false
 
 class C {
     /**

--- a/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts
+++ b/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts
@@ -1,4 +1,5 @@
 // @target: esnext
+// @useDefineForClassFields: false
 
 // declarations
 declare const invalidUniqueType: unique number;


### PR DESCRIPTION
Fixes #41788 

Fixed as described in [comment](https://github.com/microsoft/TypeScript/issues/41788#issuecomment-765400277)

> 1. If `target:esnext`,then `useDefineForClassFields: true` will now be the default.
> 2. If `target:esnext, useDefineForClassFields: true` we emit correct code so no further action is needed ([ex](https://www.typescriptlang.org/play?useDefineForClassFields=true&target=6#code/FAYwNghgzlAECCsDexZtgYgB6wFywFcA7AEwFMAzASyLJIG5V0oAXCFqkWAIVgF5Y4aHBToxggPZFWAJwIgWEmQAoAlMibjxtAO4I1AOmyMtaAL6bYFsa3adYAYX6wKxBVSlqNp2Lv2qjLBN0a3RgCz94A256IA))
> 3. If `target:esnext, useDefineForClassFields: false` and we encounter a usage of a `#private` field  in a static member we emit an error like "You can't do this, change useDefineForClassFields: true, or target an earlier version of ES."