### PR TITLE
Set Error.prototype.cause type to unknown

### DIFF
--- a/src/lib/es2022.error.d.ts
+++ b/src/lib/es2022.error.d.ts
@@ -1,9 +1,9 @@
 interface ErrorOptions {
-    cause?: Error;
+    cause?: unknown;
 }
 
 interface Error {
-    cause?: Error;
+    cause?: unknown;
 }
 
 interface ErrorConstructor {

--- a/tests/baselines/reference/errorCause(target=es2021).errors.txt
+++ b/tests/baselines/reference/errorCause(target=es2021).errors.txt
@@ -1,24 +1,38 @@
-tests/cases/compiler/errorCause.ts(1,28): error TS2554: Expected 0-1 arguments, but got 2.
-tests/cases/compiler/errorCause.ts(2,5): error TS2550: Property 'cause' does not exist on type 'Error'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2022' or later.
-tests/cases/compiler/errorCause.ts(4,22): error TS2554: Expected 0-1 arguments, but got 2.
-tests/cases/compiler/errorCause.ts(5,23): error TS2554: Expected 0-1 arguments, but got 2.
-tests/cases/compiler/errorCause.ts(6,27): error TS2554: Expected 0-1 arguments, but got 2.
-tests/cases/compiler/errorCause.ts(7,24): error TS2554: Expected 0-1 arguments, but got 2.
+tests/cases/compiler/errorCause.ts(3,28): error TS2554: Expected 0-1 arguments, but got 2.
+tests/cases/compiler/errorCause.ts(4,5): error TS2550: Property 'cause' does not exist on type 'Error'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2022' or later.
+tests/cases/compiler/errorCause.ts(5,35): error TS2554: Expected 0-1 arguments, but got 2.
+tests/cases/compiler/errorCause.ts(6,12): error TS2550: Property 'cause' does not exist on type 'Error'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2022' or later.
 tests/cases/compiler/errorCause.ts(8,22): error TS2554: Expected 0-1 arguments, but got 2.
-tests/cases/compiler/errorCause.ts(9,21): error TS2554: Expected 0-1 arguments, but got 2.
-tests/cases/compiler/errorCause.ts(10,31): error TS2554: Expected 1-2 arguments, but got 3.
+tests/cases/compiler/errorCause.ts(9,22): error TS2554: Expected 0-1 arguments, but got 2.
+tests/cases/compiler/errorCause.ts(10,23): error TS2554: Expected 0-1 arguments, but got 2.
+tests/cases/compiler/errorCause.ts(11,27): error TS2554: Expected 0-1 arguments, but got 2.
+tests/cases/compiler/errorCause.ts(12,24): error TS2554: Expected 0-1 arguments, but got 2.
+tests/cases/compiler/errorCause.ts(13,22): error TS2554: Expected 0-1 arguments, but got 2.
+tests/cases/compiler/errorCause.ts(14,21): error TS2554: Expected 0-1 arguments, but got 2.
+tests/cases/compiler/errorCause.ts(15,31): error TS2554: Expected 1-2 arguments, but got 3.
 
 
-==== tests/cases/compiler/errorCause.ts (9 errors) ====
+==== tests/cases/compiler/errorCause.ts (12 errors) ====
+    declare const a: unknown;
+    
     let err = new Error("foo", { cause: new Error("bar") });
                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2554: Expected 0-1 arguments, but got 2.
     err.cause;
         ~~~~~
 !!! error TS2550: Property 'cause' does not exist on type 'Error'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2022' or later.
+    let anotherErr = new Error("foo", { cause: a });
+                                      ~~~~~~~~~~~~
+!!! error TS2554: Expected 0-1 arguments, but got 2.
+    anotherErr.cause;
+               ~~~~~
+!!! error TS2550: Property 'cause' does not exist on type 'Error'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2022' or later.
     
     new EvalError("foo", { cause: new Error("bar") });
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2554: Expected 0-1 arguments, but got 2.
+    new EvalError("foo", { cause: a });
+                         ~~~~~~~~~~~~
 !!! error TS2554: Expected 0-1 arguments, but got 2.
     new RangeError("foo", { cause: new Error("bar") });
                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/baselines/reference/errorCause(target=es2021).js
+++ b/tests/baselines/reference/errorCause(target=es2021).js
@@ -1,8 +1,13 @@
 //// [errorCause.ts]
+declare const a: unknown;
+
 let err = new Error("foo", { cause: new Error("bar") });
 err.cause;
+let anotherErr = new Error("foo", { cause: a });
+anotherErr.cause;
 
 new EvalError("foo", { cause: new Error("bar") });
+new EvalError("foo", { cause: a });
 new RangeError("foo", { cause: new Error("bar") });
 new ReferenceError("foo", { cause: new Error("bar") });
 new SyntaxError("foo", { cause: new Error("bar") });
@@ -14,7 +19,10 @@ new AggregateError([], "foo", { cause: new Error("bar") });
 //// [errorCause.js]
 let err = new Error("foo", { cause: new Error("bar") });
 err.cause;
+let anotherErr = new Error("foo", { cause: a });
+anotherErr.cause;
 new EvalError("foo", { cause: new Error("bar") });
+new EvalError("foo", { cause: a });
 new RangeError("foo", { cause: new Error("bar") });
 new ReferenceError("foo", { cause: new Error("bar") });
 new SyntaxError("foo", { cause: new Error("bar") });

--- a/tests/baselines/reference/errorCause(target=es2021).symbols
+++ b/tests/baselines/reference/errorCause(target=es2021).symbols
@@ -1,45 +1,62 @@
 === tests/cases/compiler/errorCause.ts ===
+declare const a: unknown;
+>a : Symbol(a, Decl(errorCause.ts, 0, 13))
+
 let err = new Error("foo", { cause: new Error("bar") });
->err : Symbol(err, Decl(errorCause.ts, 0, 3))
+>err : Symbol(err, Decl(errorCause.ts, 2, 3))
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->cause : Symbol(cause, Decl(errorCause.ts, 0, 28))
+>cause : Symbol(cause, Decl(errorCause.ts, 2, 28))
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 
 err.cause;
->err : Symbol(err, Decl(errorCause.ts, 0, 3))
+>err : Symbol(err, Decl(errorCause.ts, 2, 3))
+
+let anotherErr = new Error("foo", { cause: a });
+>anotherErr : Symbol(anotherErr, Decl(errorCause.ts, 4, 3))
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>cause : Symbol(cause, Decl(errorCause.ts, 4, 35))
+>a : Symbol(a, Decl(errorCause.ts, 0, 13))
+
+anotherErr.cause;
+>anotherErr : Symbol(anotherErr, Decl(errorCause.ts, 4, 3))
 
 new EvalError("foo", { cause: new Error("bar") });
 >EvalError : Symbol(EvalError, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->cause : Symbol(cause, Decl(errorCause.ts, 3, 22))
+>cause : Symbol(cause, Decl(errorCause.ts, 7, 22))
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+new EvalError("foo", { cause: a });
+>EvalError : Symbol(EvalError, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>cause : Symbol(cause, Decl(errorCause.ts, 8, 22))
+>a : Symbol(a, Decl(errorCause.ts, 0, 13))
 
 new RangeError("foo", { cause: new Error("bar") });
 >RangeError : Symbol(RangeError, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->cause : Symbol(cause, Decl(errorCause.ts, 4, 23))
+>cause : Symbol(cause, Decl(errorCause.ts, 9, 23))
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 
 new ReferenceError("foo", { cause: new Error("bar") });
 >ReferenceError : Symbol(ReferenceError, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->cause : Symbol(cause, Decl(errorCause.ts, 5, 27))
+>cause : Symbol(cause, Decl(errorCause.ts, 10, 27))
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 
 new SyntaxError("foo", { cause: new Error("bar") });
 >SyntaxError : Symbol(SyntaxError, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->cause : Symbol(cause, Decl(errorCause.ts, 6, 24))
+>cause : Symbol(cause, Decl(errorCause.ts, 11, 24))
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 
 new TypeError("foo", { cause: new Error("bar") });
 >TypeError : Symbol(TypeError, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->cause : Symbol(cause, Decl(errorCause.ts, 7, 22))
+>cause : Symbol(cause, Decl(errorCause.ts, 12, 22))
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 
 new URIError("foo", { cause: new Error("bar") });
 >URIError : Symbol(URIError, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->cause : Symbol(cause, Decl(errorCause.ts, 8, 21))
+>cause : Symbol(cause, Decl(errorCause.ts, 13, 21))
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 
 new AggregateError([], "foo", { cause: new Error("bar") });
 >AggregateError : Symbol(AggregateError, Decl(lib.es2021.promise.d.ts, --, --), Decl(lib.es2021.promise.d.ts, --, --))
->cause : Symbol(cause, Decl(errorCause.ts, 9, 31))
+>cause : Symbol(cause, Decl(errorCause.ts, 14, 31))
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 

--- a/tests/baselines/reference/errorCause(target=es2021).types
+++ b/tests/baselines/reference/errorCause(target=es2021).types
@@ -1,4 +1,7 @@
 === tests/cases/compiler/errorCause.ts ===
+declare const a: unknown;
+>a : unknown
+
 let err = new Error("foo", { cause: new Error("bar") });
 >err : Error
 >new Error("foo", { cause: new Error("bar") }) : Error
@@ -15,6 +18,20 @@ err.cause;
 >err : Error
 >cause : any
 
+let anotherErr = new Error("foo", { cause: a });
+>anotherErr : Error
+>new Error("foo", { cause: a }) : Error
+>Error : ErrorConstructor
+>"foo" : "foo"
+>{ cause: a } : { cause: unknown; }
+>cause : unknown
+>a : unknown
+
+anotherErr.cause;
+>anotherErr.cause : any
+>anotherErr : Error
+>cause : any
+
 new EvalError("foo", { cause: new Error("bar") });
 >new EvalError("foo", { cause: new Error("bar") }) : EvalError & Error
 >EvalError : EvalErrorConstructor
@@ -24,6 +41,14 @@ new EvalError("foo", { cause: new Error("bar") });
 >new Error("bar") : Error
 >Error : ErrorConstructor
 >"bar" : "bar"
+
+new EvalError("foo", { cause: a });
+>new EvalError("foo", { cause: a }) : EvalError & Error
+>EvalError : EvalErrorConstructor
+>"foo" : "foo"
+>{ cause: a } : { cause: unknown; }
+>cause : unknown
+>a : unknown
 
 new RangeError("foo", { cause: new Error("bar") });
 >new RangeError("foo", { cause: new Error("bar") }) : RangeError & Error

--- a/tests/baselines/reference/errorCause(target=es2022).js
+++ b/tests/baselines/reference/errorCause(target=es2022).js
@@ -1,8 +1,13 @@
 //// [errorCause.ts]
+declare const a: unknown;
+
 let err = new Error("foo", { cause: new Error("bar") });
 err.cause;
+let anotherErr = new Error("foo", { cause: a });
+anotherErr.cause;
 
 new EvalError("foo", { cause: new Error("bar") });
+new EvalError("foo", { cause: a });
 new RangeError("foo", { cause: new Error("bar") });
 new ReferenceError("foo", { cause: new Error("bar") });
 new SyntaxError("foo", { cause: new Error("bar") });
@@ -14,7 +19,10 @@ new AggregateError([], "foo", { cause: new Error("bar") });
 //// [errorCause.js]
 let err = new Error("foo", { cause: new Error("bar") });
 err.cause;
+let anotherErr = new Error("foo", { cause: a });
+anotherErr.cause;
 new EvalError("foo", { cause: new Error("bar") });
+new EvalError("foo", { cause: a });
 new RangeError("foo", { cause: new Error("bar") });
 new ReferenceError("foo", { cause: new Error("bar") });
 new SyntaxError("foo", { cause: new Error("bar") });

--- a/tests/baselines/reference/errorCause(target=es2022).symbols
+++ b/tests/baselines/reference/errorCause(target=es2022).symbols
@@ -1,47 +1,66 @@
 === tests/cases/compiler/errorCause.ts ===
+declare const a: unknown;
+>a : Symbol(a, Decl(errorCause.ts, 0, 13))
+
 let err = new Error("foo", { cause: new Error("bar") });
->err : Symbol(err, Decl(errorCause.ts, 0, 3))
+>err : Symbol(err, Decl(errorCause.ts, 2, 3))
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
->cause : Symbol(cause, Decl(errorCause.ts, 0, 28))
+>cause : Symbol(cause, Decl(errorCause.ts, 2, 28))
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
 
 err.cause;
 >err.cause : Symbol(Error.cause, Decl(lib.es2022.error.d.ts, --, --))
->err : Symbol(err, Decl(errorCause.ts, 0, 3))
+>err : Symbol(err, Decl(errorCause.ts, 2, 3))
+>cause : Symbol(Error.cause, Decl(lib.es2022.error.d.ts, --, --))
+
+let anotherErr = new Error("foo", { cause: a });
+>anotherErr : Symbol(anotherErr, Decl(errorCause.ts, 4, 3))
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
+>cause : Symbol(cause, Decl(errorCause.ts, 4, 35))
+>a : Symbol(a, Decl(errorCause.ts, 0, 13))
+
+anotherErr.cause;
+>anotherErr.cause : Symbol(Error.cause, Decl(lib.es2022.error.d.ts, --, --))
+>anotherErr : Symbol(anotherErr, Decl(errorCause.ts, 4, 3))
 >cause : Symbol(Error.cause, Decl(lib.es2022.error.d.ts, --, --))
 
 new EvalError("foo", { cause: new Error("bar") });
 >EvalError : Symbol(EvalError, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->cause : Symbol(cause, Decl(errorCause.ts, 3, 22))
+>cause : Symbol(cause, Decl(errorCause.ts, 7, 22))
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
+
+new EvalError("foo", { cause: a });
+>EvalError : Symbol(EvalError, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>cause : Symbol(cause, Decl(errorCause.ts, 8, 22))
+>a : Symbol(a, Decl(errorCause.ts, 0, 13))
 
 new RangeError("foo", { cause: new Error("bar") });
 >RangeError : Symbol(RangeError, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->cause : Symbol(cause, Decl(errorCause.ts, 4, 23))
+>cause : Symbol(cause, Decl(errorCause.ts, 9, 23))
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
 
 new ReferenceError("foo", { cause: new Error("bar") });
 >ReferenceError : Symbol(ReferenceError, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->cause : Symbol(cause, Decl(errorCause.ts, 5, 27))
+>cause : Symbol(cause, Decl(errorCause.ts, 10, 27))
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
 
 new SyntaxError("foo", { cause: new Error("bar") });
 >SyntaxError : Symbol(SyntaxError, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->cause : Symbol(cause, Decl(errorCause.ts, 6, 24))
+>cause : Symbol(cause, Decl(errorCause.ts, 11, 24))
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
 
 new TypeError("foo", { cause: new Error("bar") });
 >TypeError : Symbol(TypeError, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->cause : Symbol(cause, Decl(errorCause.ts, 7, 22))
+>cause : Symbol(cause, Decl(errorCause.ts, 12, 22))
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
 
 new URIError("foo", { cause: new Error("bar") });
 >URIError : Symbol(URIError, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->cause : Symbol(cause, Decl(errorCause.ts, 8, 21))
+>cause : Symbol(cause, Decl(errorCause.ts, 13, 21))
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
 
 new AggregateError([], "foo", { cause: new Error("bar") });
 >AggregateError : Symbol(AggregateError, Decl(lib.es2021.promise.d.ts, --, --), Decl(lib.es2021.promise.d.ts, --, --))
->cause : Symbol(cause, Decl(errorCause.ts, 9, 31))
+>cause : Symbol(cause, Decl(errorCause.ts, 14, 31))
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
 

--- a/tests/baselines/reference/errorCause(target=es2022).types
+++ b/tests/baselines/reference/errorCause(target=es2022).types
@@ -1,4 +1,7 @@
 === tests/cases/compiler/errorCause.ts ===
+declare const a: unknown;
+>a : unknown
+
 let err = new Error("foo", { cause: new Error("bar") });
 >err : Error
 >new Error("foo", { cause: new Error("bar") }) : Error
@@ -11,9 +14,23 @@ let err = new Error("foo", { cause: new Error("bar") });
 >"bar" : "bar"
 
 err.cause;
->err.cause : Error
+>err.cause : unknown
 >err : Error
->cause : Error
+>cause : unknown
+
+let anotherErr = new Error("foo", { cause: a });
+>anotherErr : Error
+>new Error("foo", { cause: a }) : Error
+>Error : ErrorConstructor
+>"foo" : "foo"
+>{ cause: a } : { cause: unknown; }
+>cause : unknown
+>a : unknown
+
+anotherErr.cause;
+>anotherErr.cause : unknown
+>anotherErr : Error
+>cause : unknown
 
 new EvalError("foo", { cause: new Error("bar") });
 >new EvalError("foo", { cause: new Error("bar") }) : EvalError
@@ -24,6 +41,14 @@ new EvalError("foo", { cause: new Error("bar") });
 >new Error("bar") : Error
 >Error : ErrorConstructor
 >"bar" : "bar"
+
+new EvalError("foo", { cause: a });
+>new EvalError("foo", { cause: a }) : EvalError
+>EvalError : EvalErrorConstructor
+>"foo" : "foo"
+>{ cause: a } : { cause: unknown; }
+>cause : unknown
+>a : unknown
 
 new RangeError("foo", { cause: new Error("bar") });
 >new RangeError("foo", { cause: new Error("bar") }) : RangeError

--- a/tests/baselines/reference/errorCause(target=esnext).js
+++ b/tests/baselines/reference/errorCause(target=esnext).js
@@ -1,8 +1,13 @@
 //// [errorCause.ts]
+declare const a: unknown;
+
 let err = new Error("foo", { cause: new Error("bar") });
 err.cause;
+let anotherErr = new Error("foo", { cause: a });
+anotherErr.cause;
 
 new EvalError("foo", { cause: new Error("bar") });
+new EvalError("foo", { cause: a });
 new RangeError("foo", { cause: new Error("bar") });
 new ReferenceError("foo", { cause: new Error("bar") });
 new SyntaxError("foo", { cause: new Error("bar") });
@@ -14,7 +19,10 @@ new AggregateError([], "foo", { cause: new Error("bar") });
 //// [errorCause.js]
 let err = new Error("foo", { cause: new Error("bar") });
 err.cause;
+let anotherErr = new Error("foo", { cause: a });
+anotherErr.cause;
 new EvalError("foo", { cause: new Error("bar") });
+new EvalError("foo", { cause: a });
 new RangeError("foo", { cause: new Error("bar") });
 new ReferenceError("foo", { cause: new Error("bar") });
 new SyntaxError("foo", { cause: new Error("bar") });

--- a/tests/baselines/reference/errorCause(target=esnext).symbols
+++ b/tests/baselines/reference/errorCause(target=esnext).symbols
@@ -1,47 +1,66 @@
 === tests/cases/compiler/errorCause.ts ===
+declare const a: unknown;
+>a : Symbol(a, Decl(errorCause.ts, 0, 13))
+
 let err = new Error("foo", { cause: new Error("bar") });
->err : Symbol(err, Decl(errorCause.ts, 0, 3))
+>err : Symbol(err, Decl(errorCause.ts, 2, 3))
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
->cause : Symbol(cause, Decl(errorCause.ts, 0, 28))
+>cause : Symbol(cause, Decl(errorCause.ts, 2, 28))
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
 
 err.cause;
 >err.cause : Symbol(Error.cause, Decl(lib.es2022.error.d.ts, --, --))
->err : Symbol(err, Decl(errorCause.ts, 0, 3))
+>err : Symbol(err, Decl(errorCause.ts, 2, 3))
+>cause : Symbol(Error.cause, Decl(lib.es2022.error.d.ts, --, --))
+
+let anotherErr = new Error("foo", { cause: a });
+>anotherErr : Symbol(anotherErr, Decl(errorCause.ts, 4, 3))
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
+>cause : Symbol(cause, Decl(errorCause.ts, 4, 35))
+>a : Symbol(a, Decl(errorCause.ts, 0, 13))
+
+anotherErr.cause;
+>anotherErr.cause : Symbol(Error.cause, Decl(lib.es2022.error.d.ts, --, --))
+>anotherErr : Symbol(anotherErr, Decl(errorCause.ts, 4, 3))
 >cause : Symbol(Error.cause, Decl(lib.es2022.error.d.ts, --, --))
 
 new EvalError("foo", { cause: new Error("bar") });
 >EvalError : Symbol(EvalError, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->cause : Symbol(cause, Decl(errorCause.ts, 3, 22))
+>cause : Symbol(cause, Decl(errorCause.ts, 7, 22))
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
+
+new EvalError("foo", { cause: a });
+>EvalError : Symbol(EvalError, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>cause : Symbol(cause, Decl(errorCause.ts, 8, 22))
+>a : Symbol(a, Decl(errorCause.ts, 0, 13))
 
 new RangeError("foo", { cause: new Error("bar") });
 >RangeError : Symbol(RangeError, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->cause : Symbol(cause, Decl(errorCause.ts, 4, 23))
+>cause : Symbol(cause, Decl(errorCause.ts, 9, 23))
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
 
 new ReferenceError("foo", { cause: new Error("bar") });
 >ReferenceError : Symbol(ReferenceError, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->cause : Symbol(cause, Decl(errorCause.ts, 5, 27))
+>cause : Symbol(cause, Decl(errorCause.ts, 10, 27))
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
 
 new SyntaxError("foo", { cause: new Error("bar") });
 >SyntaxError : Symbol(SyntaxError, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->cause : Symbol(cause, Decl(errorCause.ts, 6, 24))
+>cause : Symbol(cause, Decl(errorCause.ts, 11, 24))
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
 
 new TypeError("foo", { cause: new Error("bar") });
 >TypeError : Symbol(TypeError, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->cause : Symbol(cause, Decl(errorCause.ts, 7, 22))
+>cause : Symbol(cause, Decl(errorCause.ts, 12, 22))
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
 
 new URIError("foo", { cause: new Error("bar") });
 >URIError : Symbol(URIError, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->cause : Symbol(cause, Decl(errorCause.ts, 8, 21))
+>cause : Symbol(cause, Decl(errorCause.ts, 13, 21))
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
 
 new AggregateError([], "foo", { cause: new Error("bar") });
 >AggregateError : Symbol(AggregateError, Decl(lib.es2021.promise.d.ts, --, --), Decl(lib.es2021.promise.d.ts, --, --))
->cause : Symbol(cause, Decl(errorCause.ts, 9, 31))
+>cause : Symbol(cause, Decl(errorCause.ts, 14, 31))
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
 

--- a/tests/baselines/reference/errorCause(target=esnext).types
+++ b/tests/baselines/reference/errorCause(target=esnext).types
@@ -1,4 +1,7 @@
 === tests/cases/compiler/errorCause.ts ===
+declare const a: unknown;
+>a : unknown
+
 let err = new Error("foo", { cause: new Error("bar") });
 >err : Error
 >new Error("foo", { cause: new Error("bar") }) : Error
@@ -11,9 +14,23 @@ let err = new Error("foo", { cause: new Error("bar") });
 >"bar" : "bar"
 
 err.cause;
->err.cause : Error
+>err.cause : unknown
 >err : Error
->cause : Error
+>cause : unknown
+
+let anotherErr = new Error("foo", { cause: a });
+>anotherErr : Error
+>new Error("foo", { cause: a }) : Error
+>Error : ErrorConstructor
+>"foo" : "foo"
+>{ cause: a } : { cause: unknown; }
+>cause : unknown
+>a : unknown
+
+anotherErr.cause;
+>anotherErr.cause : unknown
+>anotherErr : Error
+>cause : unknown
 
 new EvalError("foo", { cause: new Error("bar") });
 >new EvalError("foo", { cause: new Error("bar") }) : EvalError
@@ -24,6 +41,14 @@ new EvalError("foo", { cause: new Error("bar") });
 >new Error("bar") : Error
 >Error : ErrorConstructor
 >"bar" : "bar"
+
+new EvalError("foo", { cause: a });
+>new EvalError("foo", { cause: a }) : EvalError
+>EvalError : EvalErrorConstructor
+>"foo" : "foo"
+>{ cause: a } : { cause: unknown; }
+>cause : unknown
+>a : unknown
 
 new RangeError("foo", { cause: new Error("bar") });
 >new RangeError("foo", { cause: new Error("bar") }) : RangeError

--- a/tests/cases/compiler/errorCause.ts
+++ b/tests/cases/compiler/errorCause.ts
@@ -1,9 +1,14 @@
 // @target: es2021, es2022, esnext
 
+declare const a: unknown;
+
 let err = new Error("foo", { cause: new Error("bar") });
 err.cause;
+let anotherErr = new Error("foo", { cause: a });
+anotherErr.cause;
 
 new EvalError("foo", { cause: new Error("bar") });
+new EvalError("foo", { cause: a });
 new RangeError("foo", { cause: new Error("bar") });
 new ReferenceError("foo", { cause: new Error("bar") });
 new SyntaxError("foo", { cause: new Error("bar") });


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #45167

**Describe your changes**
The PR fixes [45167](https://github.com/microsoft/TypeScript/issues/45167) which changes the type of `Error.prototype.cause` from `Error` to `Unknown`

**Testing performed**
I added new test to ensure that unknown type is recognised


