### PR TITLE
Infer instance type arguments as constraint

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -383,6 +383,7 @@ m2: ${(this.mapper2 as unknown as DebugTypeMapper).__debugToString().split("\n")
         const noImplicitAny = getStrictOptionValue(compilerOptions, "noImplicitAny");
         const noImplicitThis = getStrictOptionValue(compilerOptions, "noImplicitThis");
         const useUnknownInCatchVariables = getStrictOptionValue(compilerOptions, "useUnknownInCatchVariables");
+        const inferInstanceTypeArgumentsAsConstraint = getStrictOptionValue(compilerOptions, "inferInstanceTypeArgumentsAsConstraint");
         const keyofStringsOnly = !!compilerOptions.keyofStringsOnly;
         const freshObjectLiteralFlag = compilerOptions.suppressExcessPropertyErrors ? 0 : ObjectFlags.FreshLiteral;
         const exactOptionalPropertyTypes = compilerOptions.exactOptionalPropertyTypes;
@@ -8657,13 +8658,25 @@ m2: ${(this.mapper2 as unknown as DebugTypeMapper).__debugToString().split("\n")
             })!.parent;
         }
 
+        function getInstanceTypeOfClassSymbol(classSymbol: Symbol): Type {
+            const classType = getDeclaredTypeOfSymbol(classSymbol) as InterfaceType;
+            if (!classType.typeParameters) {
+                return classType;
+            }
+            const typeArguments = map(classType.typeParameters, typeParameter => {
+                return (inferInstanceTypeArgumentsAsConstraint) ? getBaseConstraintOfType(typeParameter) || unknownType : anyType;
+            });
+            return createTypeReference(classType as GenericType, typeArguments);
+        }
+
         function getTypeOfPrototypeProperty(prototype: Symbol): Type {
             // TypeScript 1.0 spec (April 2014): 8.4
             // Every class automatically contains a static property member named 'prototype',
             // the type of which is an instantiation of the class type with type Any supplied as a type argument for each type parameter.
+            // FIXME: this needs to be updated to address new behavior with inferInstanceTypeArgumentsAsConstraint
             // It is an error to explicitly declare a static property member with the name 'prototype'.
-            const classType = getDeclaredTypeOfSymbol(getParentOfSymbol(prototype)!) as InterfaceType;
-            return classType.typeParameters ? createTypeReference(classType as GenericType, map(classType.typeParameters, _ => anyType)) : classType;
+            const classSymbol = getParentOfSymbol(prototype)!;
+            return getInstanceTypeOfClassSymbol(classSymbol);
         }
 
         // Return the type of the given property in the given type, or undefined if no such property exists
@@ -25080,10 +25093,10 @@ m2: ${(this.mapper2 as unknown as DebugTypeMapper).__debugToString().split("\n")
                 if (symbol === undefined) {
                     return type;
                 }
-                const classSymbol = symbol.parent!;
+                const classSymbol = getParentOfSymbol(symbol)!;
                 const targetType = hasStaticModifier(Debug.checkDefined(symbol.valueDeclaration, "should always have a declaration"))
                     ? getTypeOfSymbol(classSymbol) as InterfaceType
-                    : getDeclaredTypeOfSymbol(classSymbol);
+                    : getInstanceTypeOfClassSymbol(classSymbol);
                 return getNarrowedType(type, targetType, assumeTrue, isTypeDerivedFrom);
             }
 

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -740,6 +740,16 @@ namespace ts {
             defaultValueDescription: false,
         },
         {
+            name: "inferInstanceTypeArgumentsAsConstraint",
+            type: "boolean",
+            affectsSemanticDiagnostics: true,
+            affectsMultiFileEmitBuildInfo: true,
+            strictFlag: true,
+            category: Diagnostics.Type_Checking,
+            description: Diagnostics.Default_type_arguments_to_parameter_constraint_or_unknown_instead_of_any,
+            defaultValueDescription: false,
+        },
+        {
             name: "alwaysStrict",
             type: "boolean",
             affectsSourceFile: true,

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -5839,6 +5839,10 @@
         "category": "Message",
         "code": 6803
     },
+    "Default type arguments to parameter constraint or 'unknown' instead of 'any'.": {
+        "category": "Message",
+        "code": 6804
+    },
 
     "one of:": {
         "category": "Message",

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6334,6 +6334,7 @@ namespace ts {
         /*@internal*/help?: boolean;
         importHelpers?: boolean;
         importsNotUsedAsValues?: ImportsNotUsedAsValues;
+        inferInstanceTypeArgumentsAsConstraint?: boolean;
         /*@internal*/init?: boolean;
         inlineSourceMap?: boolean;
         inlineSources?: boolean;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -6461,6 +6461,7 @@ namespace ts {
         | "strictPropertyInitialization"
         | "alwaysStrict"
         | "useUnknownInCatchVariables"
+        | "inferInstanceTypeArgumentsAsConstraint"
         ;
 
     export function getStrictOptionValue(compilerOptions: CompilerOptions, flag: StrictOptionName): boolean {

--- a/tests/baselines/reference/accessorsOverrideProperty9.types
+++ b/tests/baselines/reference/accessorsOverrideProperty9.types
@@ -68,7 +68,7 @@ function ApiItemContainerMixin<TBaseClass extends IApiItemConstructor>(
   }
 
   return MixedClass;
->MixedClass : ((abstract new (...args: any[]) => MixedClass) & { prototype: ApiItemContainerMixin<any>.MixedClass; }) & TBaseClass
+>MixedClass : ((abstract new (...args: any[]) => MixedClass) & { prototype: ApiItemContainerMixin<IApiItemConstructor>.MixedClass; }) & TBaseClass
 }
 
 // Subclass inheriting from mixin

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2994,6 +2994,7 @@ declare namespace ts {
         forceConsistentCasingInFileNames?: boolean;
         importHelpers?: boolean;
         importsNotUsedAsValues?: ImportsNotUsedAsValues;
+        inferInstanceTypeArgumentsAsConstraint?: boolean;
         inlineSourceMap?: boolean;
         inlineSources?: boolean;
         isolatedModules?: boolean;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2994,6 +2994,7 @@ declare namespace ts {
         forceConsistentCasingInFileNames?: boolean;
         importHelpers?: boolean;
         importsNotUsedAsValues?: ImportsNotUsedAsValues;
+        inferInstanceTypeArgumentsAsConstraint?: boolean;
         inlineSourceMap?: boolean;
         inlineSources?: boolean;
         isolatedModules?: boolean;

--- a/tests/baselines/reference/inferInstanceTypeArgumentsAsConstraint.errors.txt
+++ b/tests/baselines/reference/inferInstanceTypeArgumentsAsConstraint.errors.txt
@@ -1,0 +1,43 @@
+tests/cases/compiler/inferInstanceTypeArgumentsAsConstraint.ts(8,13): error TS2339: Property 'toUpperCase' does not exist on type 'unknown'.
+tests/cases/compiler/inferInstanceTypeArgumentsAsConstraint.ts(9,5): error TS2356: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type.
+tests/cases/compiler/inferInstanceTypeArgumentsAsConstraint.ts(10,7): error TS2349: This expression is not callable.
+  Type '{}' has no call signatures.
+
+
+==== tests/cases/compiler/inferInstanceTypeArgumentsAsConstraint.ts (3 errors) ====
+    class Unconstrained<T> {
+        value: T;
+    }
+    
+    declare const x: unknown;
+    
+    if (x instanceof Unconstrained) {
+        x.value.toUpperCase();
+                ~~~~~~~~~~~
+!!! error TS2339: Property 'toUpperCase' does not exist on type 'unknown'.
+        x.value++;
+        ~~~~~~~
+!!! error TS2356: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type.
+        x.value();
+          ~~~~~
+!!! error TS2349: This expression is not callable.
+!!! error TS2349:   Type '{}' has no call signatures.
+    
+        if (typeof x.value === "string") {
+            x.value.toUpperCase();
+        }
+        if (typeof x.value === "number") {
+            x.value++;
+        }
+    }
+    
+    class Constrained<T extends number> {
+        value: T;
+    }
+    
+    declare const y: unknown;
+    
+    if (y instanceof Constrained) {
+        y.value++;
+    }
+    

--- a/tests/baselines/reference/inferInstanceTypeArgumentsAsConstraint.js
+++ b/tests/baselines/reference/inferInstanceTypeArgumentsAsConstraint.js
@@ -1,0 +1,56 @@
+//// [inferInstanceTypeArgumentsAsConstraint.ts]
+class Unconstrained<T> {
+    value: T;
+}
+
+declare const x: unknown;
+
+if (x instanceof Unconstrained) {
+    x.value.toUpperCase();
+    x.value++;
+    x.value();
+
+    if (typeof x.value === "string") {
+        x.value.toUpperCase();
+    }
+    if (typeof x.value === "number") {
+        x.value++;
+    }
+}
+
+class Constrained<T extends number> {
+    value: T;
+}
+
+declare const y: unknown;
+
+if (y instanceof Constrained) {
+    y.value++;
+}
+
+
+//// [inferInstanceTypeArgumentsAsConstraint.js]
+var Unconstrained = /** @class */ (function () {
+    function Unconstrained() {
+    }
+    return Unconstrained;
+}());
+if (x instanceof Unconstrained) {
+    x.value.toUpperCase();
+    x.value++;
+    x.value();
+    if (typeof x.value === "string") {
+        x.value.toUpperCase();
+    }
+    if (typeof x.value === "number") {
+        x.value++;
+    }
+}
+var Constrained = /** @class */ (function () {
+    function Constrained() {
+    }
+    return Constrained;
+}());
+if (y instanceof Constrained) {
+    y.value++;
+}

--- a/tests/baselines/reference/inferInstanceTypeArgumentsAsConstraint.symbols
+++ b/tests/baselines/reference/inferInstanceTypeArgumentsAsConstraint.symbols
@@ -1,0 +1,78 @@
+=== tests/cases/compiler/inferInstanceTypeArgumentsAsConstraint.ts ===
+class Unconstrained<T> {
+>Unconstrained : Symbol(Unconstrained, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 0, 0))
+>T : Symbol(T, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 0, 20))
+
+    value: T;
+>value : Symbol(Unconstrained.value, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 0, 24))
+>T : Symbol(T, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 0, 20))
+}
+
+declare const x: unknown;
+>x : Symbol(x, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 4, 13))
+
+if (x instanceof Unconstrained) {
+>x : Symbol(x, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 4, 13))
+>Unconstrained : Symbol(Unconstrained, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 0, 0))
+
+    x.value.toUpperCase();
+>x.value : Symbol(Unconstrained.value, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 0, 24))
+>x : Symbol(x, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 4, 13))
+>value : Symbol(Unconstrained.value, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 0, 24))
+
+    x.value++;
+>x.value : Symbol(Unconstrained.value, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 0, 24))
+>x : Symbol(x, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 4, 13))
+>value : Symbol(Unconstrained.value, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 0, 24))
+
+    x.value();
+>x.value : Symbol(Unconstrained.value, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 0, 24))
+>x : Symbol(x, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 4, 13))
+>value : Symbol(Unconstrained.value, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 0, 24))
+
+    if (typeof x.value === "string") {
+>x.value : Symbol(Unconstrained.value, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 0, 24))
+>x : Symbol(x, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 4, 13))
+>value : Symbol(Unconstrained.value, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 0, 24))
+
+        x.value.toUpperCase();
+>x.value.toUpperCase : Symbol(String.toUpperCase, Decl(lib.es5.d.ts, --, --))
+>x.value : Symbol(Unconstrained.value, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 0, 24))
+>x : Symbol(x, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 4, 13))
+>value : Symbol(Unconstrained.value, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 0, 24))
+>toUpperCase : Symbol(String.toUpperCase, Decl(lib.es5.d.ts, --, --))
+    }
+    if (typeof x.value === "number") {
+>x.value : Symbol(Unconstrained.value, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 0, 24))
+>x : Symbol(x, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 4, 13))
+>value : Symbol(Unconstrained.value, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 0, 24))
+
+        x.value++;
+>x.value : Symbol(Unconstrained.value, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 0, 24))
+>x : Symbol(x, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 4, 13))
+>value : Symbol(Unconstrained.value, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 0, 24))
+    }
+}
+
+class Constrained<T extends number> {
+>Constrained : Symbol(Constrained, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 17, 1))
+>T : Symbol(T, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 19, 18))
+
+    value: T;
+>value : Symbol(Constrained.value, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 19, 37))
+>T : Symbol(T, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 19, 18))
+}
+
+declare const y: unknown;
+>y : Symbol(y, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 23, 13))
+
+if (y instanceof Constrained) {
+>y : Symbol(y, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 23, 13))
+>Constrained : Symbol(Constrained, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 17, 1))
+
+    y.value++;
+>y.value : Symbol(Constrained.value, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 19, 37))
+>y : Symbol(y, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 23, 13))
+>value : Symbol(Constrained.value, Decl(inferInstanceTypeArgumentsAsConstraint.ts, 19, 37))
+}
+

--- a/tests/baselines/reference/inferInstanceTypeArgumentsAsConstraint.types
+++ b/tests/baselines/reference/inferInstanceTypeArgumentsAsConstraint.types
@@ -1,0 +1,90 @@
+=== tests/cases/compiler/inferInstanceTypeArgumentsAsConstraint.ts ===
+class Unconstrained<T> {
+>Unconstrained : Unconstrained<T>
+
+    value: T;
+>value : T
+}
+
+declare const x: unknown;
+>x : unknown
+
+if (x instanceof Unconstrained) {
+>x instanceof Unconstrained : boolean
+>x : unknown
+>Unconstrained : typeof Unconstrained
+
+    x.value.toUpperCase();
+>x.value.toUpperCase() : any
+>x.value.toUpperCase : any
+>x.value : unknown
+>x : Unconstrained<unknown>
+>value : unknown
+>toUpperCase : any
+
+    x.value++;
+>x.value++ : number
+>x.value : unknown
+>x : Unconstrained<unknown>
+>value : unknown
+
+    x.value();
+>x.value() : any
+>x.value : unknown
+>x : Unconstrained<unknown>
+>value : unknown
+
+    if (typeof x.value === "string") {
+>typeof x.value === "string" : boolean
+>typeof x.value : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x.value : unknown
+>x : Unconstrained<unknown>
+>value : unknown
+>"string" : "string"
+
+        x.value.toUpperCase();
+>x.value.toUpperCase() : string
+>x.value.toUpperCase : () => string
+>x.value : string
+>x : Unconstrained<unknown>
+>value : string
+>toUpperCase : () => string
+    }
+    if (typeof x.value === "number") {
+>typeof x.value === "number" : boolean
+>typeof x.value : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x.value : unknown
+>x : Unconstrained<unknown>
+>value : unknown
+>"number" : "number"
+
+        x.value++;
+>x.value++ : number
+>x.value : number
+>x : Unconstrained<unknown>
+>value : number
+    }
+}
+
+class Constrained<T extends number> {
+>Constrained : Constrained<T>
+
+    value: T;
+>value : T
+}
+
+declare const y: unknown;
+>y : unknown
+
+if (y instanceof Constrained) {
+>y instanceof Constrained : boolean
+>y : unknown
+>Constrained : typeof Constrained
+
+    y.value++;
+>y.value++ : number
+>y.value : number
+>y : Constrained<number>
+>value : number
+}
+

--- a/tests/baselines/reference/inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.errors.txt
+++ b/tests/baselines/reference/inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.errors.txt
@@ -1,0 +1,36 @@
+tests/cases/compiler/inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts(9,13): error TS2322: Type 'unknown' is not assignable to type 'T'.
+  'T' could be instantiated with an arbitrary type which could be unrelated to 'unknown'.
+tests/cases/compiler/inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts(19,13): error TS2322: Type 'string' is not assignable to type 'T'.
+  'string' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'string'.
+
+
+==== tests/cases/compiler/inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts (2 errors) ====
+    class UnconstrainedWithPrivate<T> {
+        #brand;
+        value: T;
+        constructor(value: T) {
+            this.value = value;
+        }
+        copyValue(other: object) {
+            if (#brand in other) {
+                this.value = other.value;
+                ~~~~~~~~~~
+!!! error TS2322: Type 'unknown' is not assignable to type 'T'.
+!!! error TS2322:   'T' could be instantiated with an arbitrary type which could be unrelated to 'unknown'.
+            }
+        }
+    }
+    
+    class ConstrainedWithPrivate<T extends string> {
+        #brand;
+        value: T;
+        copyValue(other: object) {
+            if (#brand in other) {
+                this.value = other.value;
+                ~~~~~~~~~~
+!!! error TS2322: Type 'string' is not assignable to type 'T'.
+!!! error TS2322:   'string' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'string'.
+            }
+        }
+    }
+    

--- a/tests/baselines/reference/inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.js
+++ b/tests/baselines/reference/inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.js
@@ -1,0 +1,54 @@
+//// [inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts]
+class UnconstrainedWithPrivate<T> {
+    #brand;
+    value: T;
+    constructor(value: T) {
+        this.value = value;
+    }
+    copyValue(other: object) {
+        if (#brand in other) {
+            this.value = other.value;
+        }
+    }
+}
+
+class ConstrainedWithPrivate<T extends string> {
+    #brand;
+    value: T;
+    copyValue(other: object) {
+        if (#brand in other) {
+            this.value = other.value;
+        }
+    }
+}
+
+
+//// [inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.js]
+var __classPrivateFieldIn = (this && this.__classPrivateFieldIn) || function(state, receiver) {
+    if (receiver === null || (typeof receiver !== "object" && typeof receiver !== "function")) throw new TypeError("Cannot use 'in' operator on non-object");
+    return typeof state === "function" ? receiver === state : state.has(receiver);
+};
+var _UnconstrainedWithPrivate_brand, _ConstrainedWithPrivate_brand;
+class UnconstrainedWithPrivate {
+    constructor(value) {
+        _UnconstrainedWithPrivate_brand.set(this, void 0);
+        this.value = value;
+    }
+    copyValue(other) {
+        if (__classPrivateFieldIn(_UnconstrainedWithPrivate_brand, other)) {
+            this.value = other.value;
+        }
+    }
+}
+_UnconstrainedWithPrivate_brand = new WeakMap();
+class ConstrainedWithPrivate {
+    constructor() {
+        _ConstrainedWithPrivate_brand.set(this, void 0);
+    }
+    copyValue(other) {
+        if (__classPrivateFieldIn(_ConstrainedWithPrivate_brand, other)) {
+            this.value = other.value;
+        }
+    }
+}
+_ConstrainedWithPrivate_brand = new WeakMap();

--- a/tests/baselines/reference/inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.symbols
+++ b/tests/baselines/reference/inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.symbols
@@ -1,0 +1,71 @@
+=== tests/cases/compiler/inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts ===
+class UnconstrainedWithPrivate<T> {
+>UnconstrainedWithPrivate : Symbol(UnconstrainedWithPrivate, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 0, 0))
+>T : Symbol(T, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 0, 31))
+
+    #brand;
+>#brand : Symbol(UnconstrainedWithPrivate.#brand, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 0, 35))
+
+    value: T;
+>value : Symbol(UnconstrainedWithPrivate.value, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 1, 11))
+>T : Symbol(T, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 0, 31))
+
+    constructor(value: T) {
+>value : Symbol(value, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 3, 16))
+>T : Symbol(T, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 0, 31))
+
+        this.value = value;
+>this.value : Symbol(UnconstrainedWithPrivate.value, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 1, 11))
+>this : Symbol(UnconstrainedWithPrivate, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 0, 0))
+>value : Symbol(UnconstrainedWithPrivate.value, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 1, 11))
+>value : Symbol(value, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 3, 16))
+    }
+    copyValue(other: object) {
+>copyValue : Symbol(UnconstrainedWithPrivate.copyValue, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 5, 5))
+>other : Symbol(other, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 6, 14))
+
+        if (#brand in other) {
+>#brand : Symbol(UnconstrainedWithPrivate.#brand, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 0, 35))
+>other : Symbol(other, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 6, 14))
+
+            this.value = other.value;
+>this.value : Symbol(UnconstrainedWithPrivate.value, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 1, 11))
+>this : Symbol(UnconstrainedWithPrivate, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 0, 0))
+>value : Symbol(UnconstrainedWithPrivate.value, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 1, 11))
+>other.value : Symbol(UnconstrainedWithPrivate.value, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 1, 11))
+>other : Symbol(other, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 6, 14))
+>value : Symbol(UnconstrainedWithPrivate.value, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 1, 11))
+        }
+    }
+}
+
+class ConstrainedWithPrivate<T extends string> {
+>ConstrainedWithPrivate : Symbol(ConstrainedWithPrivate, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 11, 1))
+>T : Symbol(T, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 13, 29))
+
+    #brand;
+>#brand : Symbol(ConstrainedWithPrivate.#brand, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 13, 48))
+
+    value: T;
+>value : Symbol(ConstrainedWithPrivate.value, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 14, 11))
+>T : Symbol(T, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 13, 29))
+
+    copyValue(other: object) {
+>copyValue : Symbol(ConstrainedWithPrivate.copyValue, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 15, 13))
+>other : Symbol(other, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 16, 14))
+
+        if (#brand in other) {
+>#brand : Symbol(ConstrainedWithPrivate.#brand, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 13, 48))
+>other : Symbol(other, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 16, 14))
+
+            this.value = other.value;
+>this.value : Symbol(ConstrainedWithPrivate.value, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 14, 11))
+>this : Symbol(ConstrainedWithPrivate, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 11, 1))
+>value : Symbol(ConstrainedWithPrivate.value, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 14, 11))
+>other.value : Symbol(ConstrainedWithPrivate.value, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 14, 11))
+>other : Symbol(other, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 16, 14))
+>value : Symbol(ConstrainedWithPrivate.value, Decl(inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts, 14, 11))
+        }
+    }
+}
+

--- a/tests/baselines/reference/inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.types
+++ b/tests/baselines/reference/inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.types
@@ -1,0 +1,71 @@
+=== tests/cases/compiler/inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts ===
+class UnconstrainedWithPrivate<T> {
+>UnconstrainedWithPrivate : UnconstrainedWithPrivate<T>
+
+    #brand;
+>#brand : any
+
+    value: T;
+>value : T
+
+    constructor(value: T) {
+>value : T
+
+        this.value = value;
+>this.value = value : T
+>this.value : T
+>this : this
+>value : T
+>value : T
+    }
+    copyValue(other: object) {
+>copyValue : (other: object) => void
+>other : object
+
+        if (#brand in other) {
+>#brand in other : boolean
+>#brand : any
+>other : object
+
+            this.value = other.value;
+>this.value = other.value : unknown
+>this.value : T
+>this : this
+>value : T
+>other.value : unknown
+>other : UnconstrainedWithPrivate<unknown>
+>value : unknown
+        }
+    }
+}
+
+class ConstrainedWithPrivate<T extends string> {
+>ConstrainedWithPrivate : ConstrainedWithPrivate<T>
+
+    #brand;
+>#brand : any
+
+    value: T;
+>value : T
+
+    copyValue(other: object) {
+>copyValue : (other: object) => void
+>other : object
+
+        if (#brand in other) {
+>#brand in other : boolean
+>#brand : any
+>other : object
+
+            this.value = other.value;
+>this.value = other.value : string
+>this.value : T
+>this : this
+>value : T
+>other.value : string
+>other : ConstrainedWithPrivate<string>
+>value : string
+        }
+    }
+}
+

--- a/tests/baselines/reference/instantiationExpressions.errors.txt
+++ b/tests/baselines/reference/instantiationExpressions.errors.txt
@@ -67,7 +67,7 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpr
     }
     
     function f3() {
-        let c1 = C<string>;  // { new (x: string): C<string>; f<U>(x: U): T[]; prototype: C<any>; }
+        let c1 = C<string>;  // { new (x: string): C<string>; f<U>(x: U): T[]; prototype: C<unknown>; }
         let f1 = C.f<string>;  // (x: string) => string[]
     }
     

--- a/tests/baselines/reference/instantiationExpressions.js
+++ b/tests/baselines/reference/instantiationExpressions.js
@@ -31,7 +31,7 @@ declare class C<T> {
 }
 
 function f3() {
-    let c1 = C<string>;  // { new (x: string): C<string>; f<U>(x: U): T[]; prototype: C<any>; }
+    let c1 = C<string>;  // { new (x: string): C<string>; f<U>(x: U): T[]; prototype: C<unknown>; }
     let f1 = C.f<string>;  // (x: string) => string[]
 }
 
@@ -187,7 +187,7 @@ function f2() {
     var A2 = (Array); // Error
 }
 function f3() {
-    var c1 = (C); // { new (x: string): C<string>; f<U>(x: U): T[]; prototype: C<any>; }
+    var c1 = (C); // { new (x: string): C<string>; f<U>(x: U): T[]; prototype: C<unknown>; }
     var f1 = (C.f); // (x: string) => string[]
 }
 function f10(f) {

--- a/tests/baselines/reference/instantiationExpressions.symbols
+++ b/tests/baselines/reference/instantiationExpressions.symbols
@@ -107,7 +107,7 @@ declare class C<T> {
 function f3() {
 >f3 : Symbol(f3, Decl(instantiationExpressions.ts, 29, 1))
 
-    let c1 = C<string>;  // { new (x: string): C<string>; f<U>(x: U): T[]; prototype: C<any>; }
+    let c1 = C<string>;  // { new (x: string): C<string>; f<U>(x: U): T[]; prototype: C<unknown>; }
 >c1 : Symbol(c1, Decl(instantiationExpressions.ts, 32, 7))
 >C : Symbol(C, Decl(instantiationExpressions.ts, 24, 40))
 

--- a/tests/baselines/reference/instantiationExpressions.types
+++ b/tests/baselines/reference/instantiationExpressions.types
@@ -97,9 +97,9 @@ declare class C<T> {
 function f3() {
 >f3 : () => void
 
-    let c1 = C<string>;  // { new (x: string): C<string>; f<U>(x: U): T[]; prototype: C<any>; }
->c1 : { new (x: string): C<string>; prototype: C<any>; f<U>(x: U): U[]; }
->C<string> : { new (x: string): C<string>; prototype: C<any>; f<U>(x: U): U[]; }
+    let c1 = C<string>;  // { new (x: string): C<string>; f<U>(x: U): T[]; prototype: C<unknown>; }
+>c1 : { new (x: string): C<string>; prototype: C<unknown>; f<U>(x: U): U[]; }
+>C<string> : { new (x: string): C<string>; prototype: C<unknown>; f<U>(x: U): U[]; }
 >C : typeof C
 
     let f1 = C.f<string>;  // (x: string) => string[]

--- a/tests/baselines/reference/overrideBaseIntersectionMethod.types
+++ b/tests/baselines/reference/overrideBaseIntersectionMethod.types
@@ -6,10 +6,10 @@ type Constructor<T> = new (...args: any[]) => T;
 >args : any[]
 
 const WithLocation = <T extends Constructor<Point>>(Base: T) => class extends Base {
->WithLocation : <T extends Constructor<Point>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: WithLocation<any>.(Anonymous class); } & T
-><T extends Constructor<Point>>(Base: T) => class extends Base {  getLocation(): [number, number] {    const [x,y] = super.getLocation();    return [this.x | x, this.y | y];  }} : <T extends Constructor<Point>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: WithLocation<any>.(Anonymous class); } & T
+>WithLocation : <T extends Constructor<Point>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: WithLocation<Constructor<Point>>.(Anonymous class); } & T
+><T extends Constructor<Point>>(Base: T) => class extends Base {  getLocation(): [number, number] {    const [x,y] = super.getLocation();    return [this.x | x, this.y | y];  }} : <T extends Constructor<Point>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: WithLocation<Constructor<Point>>.(Anonymous class); } & T
 >Base : T
->class extends Base {  getLocation(): [number, number] {    const [x,y] = super.getLocation();    return [this.x | x, this.y | y];  }} : { new (...args: any[]): (Anonymous class); prototype: WithLocation<any>.(Anonymous class); } & T
+>class extends Base {  getLocation(): [number, number] {    const [x,y] = super.getLocation();    return [this.x | x, this.y | y];  }} : { new (...args: any[]): (Anonymous class); prototype: WithLocation<Constructor<Point>>.(Anonymous class); } & T
 >Base : Point
 
   getLocation(): [number, number] {
@@ -58,7 +58,7 @@ class Point {
 class Foo extends WithLocation(Point) {
 >Foo : Foo
 >WithLocation(Point) : WithLocation<typeof Point>.(Anonymous class) & Point
->WithLocation : <T extends Constructor<Point>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: WithLocation<any>.(Anonymous class); } & T
+>WithLocation : <T extends Constructor<Point>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: WithLocation<Constructor<Point>>.(Anonymous class); } & T
 >Point : typeof Point
 
   calculate() {

--- a/tests/baselines/reference/showConfig/Shows tsconfig for single option/inferInstanceTypeArgumentsAsConstraint/tsconfig.json
+++ b/tests/baselines/reference/showConfig/Shows tsconfig for single option/inferInstanceTypeArgumentsAsConstraint/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "inferInstanceTypeArgumentsAsConstraint": true
+    }
+}

--- a/tests/baselines/reference/tsConfig/Default initialized TSConfig/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Default initialized TSConfig/tsconfig.json
@@ -84,6 +84,7 @@
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "inferInstanceTypeArgumentsAsConstraint": true,   /* Default type arguments to parameter constraint or 'unknown' instead of 'any'. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with advanced options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with advanced options/tsconfig.json
@@ -84,6 +84,7 @@
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "inferInstanceTypeArgumentsAsConstraint": true,   /* Default type arguments to parameter constraint or 'unknown' instead of 'any'. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with boolean value compiler options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with boolean value compiler options/tsconfig.json
@@ -84,6 +84,7 @@
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "inferInstanceTypeArgumentsAsConstraint": true,   /* Default type arguments to parameter constraint or 'unknown' instead of 'any'. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     "noUnusedLocals": true,                              /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with enum value compiler options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with enum value compiler options/tsconfig.json
@@ -84,6 +84,7 @@
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "inferInstanceTypeArgumentsAsConstraint": true,   /* Default type arguments to parameter constraint or 'unknown' instead of 'any'. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with files options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with files options/tsconfig.json
@@ -84,6 +84,7 @@
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "inferInstanceTypeArgumentsAsConstraint": true,   /* Default type arguments to parameter constraint or 'unknown' instead of 'any'. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option value/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option value/tsconfig.json
@@ -84,6 +84,7 @@
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "inferInstanceTypeArgumentsAsConstraint": true,   /* Default type arguments to parameter constraint or 'unknown' instead of 'any'. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option/tsconfig.json
@@ -84,6 +84,7 @@
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "inferInstanceTypeArgumentsAsConstraint": true,   /* Default type arguments to parameter constraint or 'unknown' instead of 'any'. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options with enum value/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options with enum value/tsconfig.json
@@ -84,6 +84,7 @@
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "inferInstanceTypeArgumentsAsConstraint": true,   /* Default type arguments to parameter constraint or 'unknown' instead of 'any'. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options/tsconfig.json
@@ -84,6 +84,7 @@
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "inferInstanceTypeArgumentsAsConstraint": true,   /* Default type arguments to parameter constraint or 'unknown' instead of 'any'. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */

--- a/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/declarationDir-is-specified.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/declarationDir-is-specified.js
@@ -105,6 +105,7 @@ interface Array<T> { length: number; [n: number]: T; }
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "inferInstanceTypeArgumentsAsConstraint": true,   /* Default type arguments to parameter constraint or 'unknown' instead of 'any'. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */

--- a/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/when-outDir-and-declarationDir-is-specified.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/when-outDir-and-declarationDir-is-specified.js
@@ -105,6 +105,7 @@ interface Array<T> { length: number; [n: number]: T; }
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "inferInstanceTypeArgumentsAsConstraint": true,   /* Default type arguments to parameter constraint or 'unknown' instead of 'any'. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */

--- a/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/when-outDir-is-specified.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/when-outDir-is-specified.js
@@ -105,6 +105,7 @@ interface Array<T> { length: number; [n: number]: T; }
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "inferInstanceTypeArgumentsAsConstraint": true,   /* Default type arguments to parameter constraint or 'unknown' instead of 'any'. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */

--- a/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/with-outFile.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/with-outFile.js
@@ -105,6 +105,7 @@ interface Array<T> { length: number; [n: number]: T; }
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "inferInstanceTypeArgumentsAsConstraint": true,   /* Default type arguments to parameter constraint or 'unknown' instead of 'any'. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */

--- a/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/without-outDir-or-outFile-is-specified-with-declaration-enabled.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/without-outDir-or-outFile-is-specified-with-declaration-enabled.js
@@ -105,6 +105,7 @@ interface Array<T> { length: number; [n: number]: T; }
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "inferInstanceTypeArgumentsAsConstraint": true,   /* Default type arguments to parameter constraint or 'unknown' instead of 'any'. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */

--- a/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/without-outDir-or-outFile-is-specified.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/should-not-trigger-recompilation-because-of-program-emit/without-outDir-or-outFile-is-specified.js
@@ -105,6 +105,7 @@ interface Array<T> { length: number; [n: number]: T; }
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "inferInstanceTypeArgumentsAsConstraint": true,   /* Default type arguments to parameter constraint or 'unknown' instead of 'any'. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */

--- a/tests/cases/compiler/inferInstanceTypeArgumentsAsConstraint.ts
+++ b/tests/cases/compiler/inferInstanceTypeArgumentsAsConstraint.ts
@@ -1,0 +1,30 @@
+// @inferInstanceTypeArgumentsAsConstraint: true
+
+class Unconstrained<T> {
+    value: T;
+}
+
+declare const x: unknown;
+
+if (x instanceof Unconstrained) {
+    x.value.toUpperCase();
+    x.value++;
+    x.value();
+
+    if (typeof x.value === "string") {
+        x.value.toUpperCase();
+    }
+    if (typeof x.value === "number") {
+        x.value++;
+    }
+}
+
+class Constrained<T extends number> {
+    value: T;
+}
+
+declare const y: unknown;
+
+if (y instanceof Constrained) {
+    y.value++;
+}

--- a/tests/cases/compiler/inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts
+++ b/tests/cases/compiler/inferInstanceTypeArgumentsAsConstraintFromPrivateNameInInExpression.ts
@@ -1,0 +1,25 @@
+// @inferInstanceTypeArgumentsAsConstraint: true
+// @target: es2015
+
+class UnconstrainedWithPrivate<T> {
+    #brand;
+    value: T;
+    constructor(value: T) {
+        this.value = value;
+    }
+    copyValue(other: object) {
+        if (#brand in other) {
+            this.value = other.value;
+        }
+    }
+}
+
+class ConstrainedWithPrivate<T extends string> {
+    #brand;
+    value: T;
+    copyValue(other: object) {
+        if (#brand in other) {
+            this.value = other.value;
+        }
+    }
+}

--- a/tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressions.ts
+++ b/tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressions.ts
@@ -33,7 +33,7 @@ declare class C<T> {
 }
 
 function f3() {
-    let c1 = C<string>;  // { new (x: string): C<string>; f<U>(x: U): T[]; prototype: C<any>; }
+    let c1 = C<string>;  // { new (x: string): C<string>; f<U>(x: U): T[]; prototype: C<unknown>; }
     let f1 = C.f<string>;  // (x: string) => string[]
 }
 


### PR DESCRIPTION
Leaving this open as a draft because I'd like to get feedback on naming/verbiage. In particular, the name of the compiler option is incredibly verbose and it would be nice to have a shorter/simpler alternative. As well, the modifications to the `instanceof` check change the behavior of something that is described in the source code as part of the "TypeScript 1.0 spec" so it is unclear how easy it will be to change that section.

-----
*Issue number of the reported bug or feature request: 17473 and 46668*

**Describe your changes**
There are certain runtime checks that can narrow the type of a variable to a class instance type:

(Issue 17473) For `instanceof` checks, TypeScript mirrors the underlying behavior of JavaScript and looks as the `Class.prototype` property. This property is computed dynamically in the checker and is then used to narrow the target of the `instanceof` expression. If the class in question has any type parameters, TypeScript returns a type reference where all of the type arguments are `any`.

(Issue 46668) For `#brand in obj` checks, TypeScript can infer that if an object has a private identifier then it must be an instance of the enclosing class. If the class in question has any type parameters, TypeScript sets all of the type arguments of the inferred type to match the type arguments of `this`.

This change addresses both of these issues by introducing a new strict compiler option `inferInstanceTypeArgumentsAsConstraint`. When it is enabled (either directly or via `strict`) the class instance type's type arguments will be set to the constraint type of the corresponding type parameter. If there is no constraint, then it will default to `unknown`.

**Testing performed**
Added new compiler test cases for direct usage of this new behavior. Also updated baseline to account for breaking changes to other tests.

**Additional context**
This PR does introduce breaking changes to both the `instanceof` and `#brand in obj` checks. As such, it was added behind a new compiler option, similar to the `useUnknownInCatchVariables` option.
