### PR TITLE
Add a fixer in the language service

### DIFF
--- a/src/services/_namespaces/ts.codefix.ts
+++ b/src/services/_namespaces/ts.codefix.ts
@@ -49,6 +49,7 @@ export * from "../codefixes/fixUnreachableCode";
 export * from "../codefixes/fixUnusedLabel";
 export * from "../codefixes/fixJSDocTypes";
 export * from "../codefixes/fixMissingCallParentheses";
+export * from "../codefixes/fixMissingTypeAnnotationOnExports";
 export * from "../codefixes/fixAwaitInSyncFunction";
 export * from "../codefixes/fixPropertyOverrideAccessor";
 export * from "../codefixes/inferFromUsage";

--- a/src/services/codefixes/fixMissingTypeAnnotationOnExports.ts
+++ b/src/services/codefixes/fixMissingTypeAnnotationOnExports.ts
@@ -1,0 +1,222 @@
+import {
+    Diagnostics,
+    factory,
+    FunctionDeclaration,
+    GetAccessorDeclaration,
+    getTokenAtPosition,
+    MethodDeclaration,
+    Node,
+    NodeArray,
+    NodeBuilderFlags,
+    ParameterDeclaration,
+    PropertyDeclaration,
+    SignatureDeclaration,
+    SourceFile,
+    SyntaxKind,
+    textChanges,
+    Type,
+    TypeChecker,
+    VariableDeclaration,
+} from "../_namespaces/ts";
+import {
+    codeFixAll,
+    createCodeFixAction,
+    registerCodeFix,
+} from "../_namespaces/ts.codefix";
+
+const fixId = "fixMissingTypeAnnotationOnExports";
+const errorCodes = [
+    Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.code,
+];
+const canHaveExplicitTypeAnnotation = new Set<SyntaxKind>([
+    SyntaxKind.GetAccessor,
+    SyntaxKind.MethodDeclaration,
+    SyntaxKind.PropertyDeclaration,
+    SyntaxKind.FunctionDeclaration,
+    SyntaxKind.VariableDeclaration,
+    SyntaxKind.Parameter,
+]);
+
+const declarationEmitNodeBuilderFlags =
+    NodeBuilderFlags.MultilineObjectLiterals |
+    NodeBuilderFlags.WriteClassExpressionAsTypeLiteral |
+    NodeBuilderFlags.UseTypeOfFunction |
+    NodeBuilderFlags.UseStructuralFallback |
+    NodeBuilderFlags.AllowEmptyTuple |
+    NodeBuilderFlags.GenerateNamesForShadowedTypeParams |
+    NodeBuilderFlags.NoTruncation;
+
+registerCodeFix({
+    errorCodes,
+    fixIds: [fixId],
+    getCodeActions(context) {
+        const { sourceFile, span } = context;
+        const nodeWithDiag = getTokenAtPosition(sourceFile, span.start);
+
+        const changes = textChanges.ChangeTracker.with(context, t => doChange(t, context.sourceFile, context.program.getTypeChecker(), nodeWithDiag));
+        return [createCodeFixAction(fixId, changes, Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit, fixId, Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit)];
+    },
+    getAllCodeActions: context => codeFixAll(context, errorCodes, (changes, diag) => {
+        const nodeWithDiag = getTokenAtPosition(diag.file, diag.start);
+        doChange(changes, diag.file, context.program.getTypeChecker(), nodeWithDiag);
+    })
+});
+
+function doChange(changes: textChanges.ChangeTracker, sourceFile: SourceFile, typeChecker: TypeChecker, nodeWithDiag: Node): void {
+    const nodeWithNoType = findNearestParentWithTypeAnnotation(nodeWithDiag);
+    const replacedNodes = addTypeAnnotationOnNode(nodeWithNoType, typeChecker);
+    changes.replaceNodeWithNodes(sourceFile, nodeWithNoType, Array.isArray(replacedNodes) ? replacedNodes : [replacedNodes]);
+}
+
+// Currently, the diagnostics for the error is not given in the exact node of which that needs type annotation
+function findNearestParentWithTypeAnnotation(node: Node): Node {
+    while (!canHaveExplicitTypeAnnotation.has(node.kind)) {
+        node = node.parent;
+    }
+    return node;
+}
+
+function addTypeAnnotationOnNode(node: Node, typeChecker: TypeChecker): Node | Node[] {
+    switch (node.kind) {
+    case SyntaxKind.Parameter:
+        const parameter = node as ParameterDeclaration;
+        const newNode = addTypeToParameterDeclaration(parameter, typeChecker);
+        if (newNode) {
+            return newNode;
+        }
+        break;
+    case SyntaxKind.VariableDeclaration:
+        const variableDeclaration = node as VariableDeclaration;
+        if (!variableDeclaration.type) {
+            const type = typeChecker.getTypeAtLocation(variableDeclaration);
+            const typeNode = typeToTypeNode(type, variableDeclaration, typeChecker);
+            return factory.updateVariableDeclaration(
+                variableDeclaration,
+                variableDeclaration.name,
+                /*exclamationToken*/ undefined,
+                typeNode,
+                variableDeclaration.initializer
+            );
+        }
+        break;
+    case SyntaxKind.FunctionDeclaration:
+        const functionDecl = node as FunctionDeclaration;
+        if (!functionDecl.type) {
+            const type = tryGetReturnType(typeChecker, functionDecl);
+            if(type) {
+                const typeNode = typeToTypeNode(type, functionDecl, typeChecker);
+                return factory.updateFunctionDeclaration(
+                    functionDecl,
+                    functionDecl.modifiers,
+                    functionDecl.asteriskToken,
+                    functionDecl.name,
+                    functionDecl.typeParameters,
+                    updateTypesInNodeArray(functionDecl.parameters, typeChecker),
+                    typeNode,
+                    functionDecl.body
+                );
+            }
+        }
+        break;
+    case SyntaxKind.PropertyDeclaration:
+        const propDecl = node as PropertyDeclaration;
+        if(!propDecl.type) {
+            const type = typeChecker.getTypeAtLocation(node);
+            const typeNode = typeToTypeNode(type, propDecl, typeChecker);
+            return factory.updatePropertyDeclaration(
+                propDecl,
+                propDecl.modifiers,
+                propDecl.name,
+                propDecl.questionToken ?? propDecl.exclamationToken,
+                typeNode,
+                propDecl.initializer
+            );
+        }
+        break;
+    case SyntaxKind.MethodDeclaration:
+        const methodDeclaration = node as MethodDeclaration;
+        if(!methodDeclaration.type) {
+            const type = tryGetReturnType(typeChecker, methodDeclaration);
+            if(type) {
+                const typeNode = typeToTypeNode(type, node, typeChecker);
+                return factory.updateMethodDeclaration(
+                    methodDeclaration,
+                    methodDeclaration.modifiers,
+                    methodDeclaration.asteriskToken,
+                    methodDeclaration.name,
+                    methodDeclaration.questionToken,
+                    methodDeclaration.typeParameters,
+                    updateTypesInNodeArray(methodDeclaration.parameters, typeChecker),
+                    typeNode,
+                    methodDeclaration.body,
+                );
+            }
+        }
+        break;
+    case SyntaxKind.GetAccessor:
+        const getAccessor = node as GetAccessorDeclaration;
+        if(!getAccessor.type) {
+            const returnType = tryGetReturnType(typeChecker, getAccessor);
+            if(returnType) {
+                const typeNode = typeToTypeNode(returnType, node, typeChecker);
+                return factory.updateGetAccessorDeclaration(
+                    getAccessor,
+                    getAccessor.modifiers,
+                    getAccessor.name,
+                    updateTypesInNodeArray(getAccessor.parameters, typeChecker),
+                    typeNode,
+                    getAccessor.body,
+                );
+            }
+        }
+        break;
+    default:
+        break;
+    }
+    throw new Error(`Cannot find a fix for the given node ${node.kind}`);
+}
+
+function typeToTypeNode(type: Type, enclosingDeclaration: Node, typeChecker: TypeChecker) {
+    const typeNode = typeChecker.typeToTypeNode(
+        type,
+        enclosingDeclaration,
+        declarationEmitNodeBuilderFlags,
+    );
+    return typeNode;
+}
+
+function tryGetReturnType(typeChecker: TypeChecker, node: SignatureDeclaration): Type | undefined {
+    const signature = typeChecker.getSignatureFromDeclaration(node);
+    if (signature) {
+        return typeChecker.getReturnTypeOfSignature(signature);
+    }
+}
+
+function updateTypesInNodeArray(nodeArray: NodeArray<ParameterDeclaration>, typeChecker: TypeChecker): NodeArray<ParameterDeclaration>;
+function updateTypesInNodeArray(nodeArray: NodeArray<ParameterDeclaration> | undefined, typeChecker: TypeChecker): NodeArray<ParameterDeclaration> | undefined;
+function updateTypesInNodeArray(nodeArray: NodeArray<ParameterDeclaration> | undefined, typeChecker: TypeChecker) {
+    if(nodeArray === undefined) return undefined;
+    return factory.createNodeArray(
+        nodeArray.map(param => {
+            return addTypeToParameterDeclaration(param, typeChecker) || param;
+        })
+    );
+}
+
+function addTypeToParameterDeclaration(parameter: ParameterDeclaration, typeChecker: TypeChecker): ParameterDeclaration | undefined {
+    if (!parameter.type) {
+        const type = typeChecker.getTypeAtLocation(parameter);
+        if (type) {
+            const typeNode = typeToTypeNode(type, parameter, typeChecker);
+            return factory.updateParameterDeclaration(
+                parameter,
+                parameter.modifiers,
+                parameter.dotDotDotToken,
+                parameter.name,
+                parameter.questionToken,
+                typeNode,
+                parameter.initializer
+            );
+        }
+    }
+}

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4604,6 +4604,7 @@ declare namespace ts {
     type HasExpressionInitializer = VariableDeclaration | ParameterDeclaration | BindingElement | PropertyDeclaration | PropertyAssignment | EnumMember;
     type HasDecorators = ParameterDeclaration | PropertyDeclaration | MethodDeclaration | GetAccessorDeclaration | SetAccessorDeclaration | ClassExpression | ClassDeclaration;
     type HasModifiers = TypeParameterDeclaration | ParameterDeclaration | ConstructorTypeNode | PropertySignature | PropertyDeclaration | MethodSignature | MethodDeclaration | ConstructorDeclaration | GetAccessorDeclaration | SetAccessorDeclaration | IndexSignatureDeclaration | FunctionExpression | ArrowFunction | ClassExpression | VariableStatement | FunctionDeclaration | ClassDeclaration | InterfaceDeclaration | TypeAliasDeclaration | EnumDeclaration | ModuleDeclaration | ImportEqualsDeclaration | ImportDeclaration | ExportAssignment | ExportDeclaration;
+    type HasInferredType = FunctionDeclaration | MethodDeclaration | GetAccessorDeclaration | SetAccessorDeclaration | BindingElement | ConstructSignatureDeclaration | VariableDeclaration | MethodSignature | CallSignatureDeclaration | ParameterDeclaration | PropertyDeclaration | PropertySignature;
     interface NodeArray<T extends Node> extends ReadonlyArray<T>, ReadonlyTextRange {
         readonly hasTrailingComma: boolean;
     }

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -557,6 +557,7 @@ declare namespace ts {
     type HasExpressionInitializer = VariableDeclaration | ParameterDeclaration | BindingElement | PropertyDeclaration | PropertyAssignment | EnumMember;
     type HasDecorators = ParameterDeclaration | PropertyDeclaration | MethodDeclaration | GetAccessorDeclaration | SetAccessorDeclaration | ClassExpression | ClassDeclaration;
     type HasModifiers = TypeParameterDeclaration | ParameterDeclaration | ConstructorTypeNode | PropertySignature | PropertyDeclaration | MethodSignature | MethodDeclaration | ConstructorDeclaration | GetAccessorDeclaration | SetAccessorDeclaration | IndexSignatureDeclaration | FunctionExpression | ArrowFunction | ClassExpression | VariableStatement | FunctionDeclaration | ClassDeclaration | InterfaceDeclaration | TypeAliasDeclaration | EnumDeclaration | ModuleDeclaration | ImportEqualsDeclaration | ImportDeclaration | ExportAssignment | ExportDeclaration;
+    type HasInferredType = FunctionDeclaration | MethodDeclaration | GetAccessorDeclaration | SetAccessorDeclaration | BindingElement | ConstructSignatureDeclaration | VariableDeclaration | MethodSignature | CallSignatureDeclaration | ParameterDeclaration | PropertyDeclaration | PropertySignature;
     interface NodeArray<T extends Node> extends ReadonlyArray<T>, ReadonlyTextRange {
         readonly hasTrailingComma: boolean;
     }

--- a/tests/baselines/reference/autoAccessorNoUseDefineForClassFields.errors.txt
+++ b/tests/baselines/reference/autoAccessorNoUseDefineForClassFields.errors.txt
@@ -1,0 +1,49 @@
+tests/cases/conformance/classes/propertyMemberDeclarations/file3-2.ts(1,7): error TS2300: Duplicate identifier 'C3'.
+tests/cases/conformance/classes/propertyMemberDeclarations/file3.ts(1,7): error TS2300: Duplicate identifier 'C3'.
+
+
+==== tests/cases/conformance/classes/propertyMemberDeclarations/file1.ts (0 errors) ====
+    // https://github.com/microsoft/TypeScript/issues/51528
+    class C1 {
+        static accessor x = 0;
+    }
+    
+==== tests/cases/conformance/classes/propertyMemberDeclarations/file2.ts (0 errors) ====
+    class C2 {
+        static accessor #x = 0;
+    }
+    
+==== tests/cases/conformance/classes/propertyMemberDeclarations/file3.ts (1 errors) ====
+    class C3 {
+          ~~
+!!! error TS2300: Duplicate identifier 'C3'.
+!!! related TS6203 tests/cases/conformance/classes/propertyMemberDeclarations/file3-2.ts:1:7: 'C3' was also declared here.
+        static accessor #x = 0;
+        accessor #y = 0;
+    }
+    
+==== tests/cases/conformance/classes/propertyMemberDeclarations/file3-2.ts (1 errors) ====
+    class C3 {
+          ~~
+!!! error TS2300: Duplicate identifier 'C3'.
+!!! related TS6203 tests/cases/conformance/classes/propertyMemberDeclarations/file3.ts:1:7: 'C3' was also declared here.
+        accessor x = 0;
+    }
+    
+==== tests/cases/conformance/classes/propertyMemberDeclarations/file4.ts (0 errors) ====
+    class C4 {
+        accessor #x = 0;
+    }
+    
+==== tests/cases/conformance/classes/propertyMemberDeclarations/file5.ts (0 errors) ====
+    class C5 {
+        x = 0;
+        accessor #x = 1;
+    }
+    
+==== tests/cases/conformance/classes/propertyMemberDeclarations/file6.ts (0 errors) ====
+    class C6 {
+        accessor #x = 0;
+        x = 1;
+    }
+    

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports.ts
@@ -1,0 +1,19 @@
+/// <reference path='fourslash.ts'/>
+
+// @isolatedDeclarations: true
+// @declaration: true
+////function foo() { return 42; }
+////export const g = foo();
+
+verify.codeFixAvailable([
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message },
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message }
+]);
+
+verify.codeFix({
+    description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message,
+    index: 0,
+    newFileContent:
+`function foo() { return 42; }
+export const g: number = foo();`,
+});

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports2.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports2.ts
@@ -1,0 +1,21 @@
+/// <reference path='fourslash.ts'/>
+
+// @isolatedDeclarations: true
+// @declaration: true
+////const a = 42;
+////const b = 43;
+////export function foo() { return a + b; }
+
+verify.codeFixAvailable([
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message },
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message }
+]);
+
+verify.codeFix({
+    description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message,
+    index: 0,
+    newFileContent:
+`const a = 42;
+const b = 43;
+export function foo(): number { return a + b; }`,
+});

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports3.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports3.ts
@@ -1,0 +1,25 @@
+/// <reference path='fourslash.ts'/>
+
+// @isolatedDeclarations: true
+// @declaration: true
+////const a = 42;
+////const b = 42;
+////export class C {
+////  property = a + b;
+////}
+
+verify.codeFixAvailable([
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message },
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message },
+]);
+
+verify.codeFix({
+    description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message,
+    index: 0,
+    newFileContent:
+`const a = 42;
+const b = 42;
+export class C {
+  property: number = a + b;
+}`,
+});

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports4.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports4.ts
@@ -1,0 +1,25 @@
+/// <reference path='fourslash.ts'/>
+
+// @isolatedDeclarations: true
+// @declaration: true
+////const a = 42;
+////const b = 42;
+////export class C {
+////  method() { return a + b};
+////}
+
+verify.codeFixAvailable([
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message },
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message },
+]);
+
+verify.codeFix({
+    description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message,
+    index: 0,
+    newFileContent:
+`const a = 42;
+const b = 42;
+export class C {
+  method(): number { return a + b; };
+}`,
+});

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports5.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports5.ts
@@ -1,0 +1,25 @@
+/// <reference path='fourslash.ts'/>
+
+// @isolatedDeclarations: true
+// @declaration: true
+////const a = 42;
+////const b = 42;
+////export class C {
+////  get property() { return a + b; }
+////}
+
+verify.codeFixAvailable([
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message },
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message }
+]);
+
+verify.codeFix({
+    description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message,
+    index: 0,
+    newFileContent:
+`const a = 42;
+const b = 42;
+export class C {
+  get property(): number { return a + b; }
+}`,
+});

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports6.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports6.ts
@@ -1,0 +1,19 @@
+/// <reference path='fourslash.ts'/>
+
+// @isolatedDeclarations: true
+// @declaration: true
+////function foo(): number[] {return [42];}
+////export const c = [...foo()];
+
+verify.codeFixAvailable([
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message },
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message }
+]);
+
+verify.codeFix({
+    description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message,
+    index: 0,
+    newFileContent:
+`function foo(): number[] {return [42];}
+export const c: number[] = [...foo()];`,
+});

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports7.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports7.ts
@@ -1,0 +1,21 @@
+/// <reference path='fourslash.ts'/>
+
+// @isolatedDeclarations: true
+// @declaration: true
+////function foo(): number[] {return [42];}
+////export const c = {foo: foo()};
+
+verify.codeFixAvailable([
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message },
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message }
+]);
+
+verify.codeFix({
+    description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message,
+    index: 0,
+    newFileContent:
+`function foo(): number[] {return [42];}
+export const c: {
+        foo: number[];
+    } = { foo: foo() };`,
+});

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports8.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports8.ts
@@ -1,0 +1,19 @@
+/// <reference path='fourslash.ts'/>
+
+// @isolatedDeclarations: true
+// @declaration: true
+////function foo() {return 42;}
+////export const g = function () { return foo(); };
+
+verify.codeFixAvailable([
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message },
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message }
+]);
+
+verify.codeFix({
+    description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message,
+    index: 0,
+    newFileContent:
+`function foo() {return 42;}
+export const g: () => number = function() { return foo(); };`,
+});

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports9.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports9.ts
@@ -1,0 +1,25 @@
+/// <reference path='fourslash.ts'/>
+
+// @isolatedDeclarations: true
+// @declaration: true
+////function foo( ){
+////    return 42;
+////}
+////const a = foo();
+////export = a;
+
+verify.codeFixAvailable([
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message },
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message }
+]);
+
+verify.codeFix({
+    description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message,
+    index: 0,
+    newFileContent:
+`function foo( ){
+    return 42;
+}
+const a: number = foo();
+export = a;`,
+});


### PR DESCRIPTION
1. Remove practically unused code from code-mode/fixer, there were some nodes that the error messages would never exist, I got rid of those cases.
2. Create fixMissingTypeAnnotationOnExports fixer, which is mostly a copy from the code-fixer
3. Updated reference tests