### PR TITLE
Support fixes for destructuring, default exports, and heritage clauses

### DIFF
--- a/src/services/codefixes/fixMissingTypeAnnotationOnExports.ts
+++ b/src/services/codefixes/fixMissingTypeAnnotationOnExports.ts
@@ -265,10 +265,10 @@ const enum ExpressionType {
     IDENTIFIER = 3,
 }
 
-type SubExpression = {kind: ExpressionType.TEXT, text: string} |
-                     {kind: ExpressionType.COMPUTED, computed: Expression} |
-                     {kind: ExpressionType.ARRAY_ACCESS, arrayIndex: number} |
-                     {kind: ExpressionType.IDENTIFIER, identifier: Identifier} ;
+type SubExpression = {kind: ExpressionType.TEXT, text: string}
+    | {kind: ExpressionType.COMPUTED, computed: Expression}
+    | {kind: ExpressionType.ARRAY_ACCESS, arrayIndex: number}
+    | {kind: ExpressionType.IDENTIFIER, identifier: Identifier};
 
 function transformDestructuringPatterns(bindingPattern: BindingPattern,
                                         sourceFile: SourceFile,
@@ -332,7 +332,7 @@ function transformDestructuringPatterns(bindingPattern: BindingPattern,
                     /*modifiers*/ undefined,
                     factory.createVariableDeclarationList(
                         [factory.createVariableDeclaration(
-                            tempName, /*exclamationToken*/ undefined, typeNode, variableInitializer)],
+                            tempName, /*exclamationToken*/ undefined, /*type*/ undefined, variableInitializer)],
                         NodeFlags.Const)));
                 variableInitializer = factory.createConditionalExpression(
                     factory.createBinaryExpression(

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports10.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports10.ts
@@ -2,13 +2,13 @@
 
 // @isolatedDeclarations: true
 // @declaration: true
-////const a = 42;
-////const b = 42;
-////export class C {
-////  get property() { return a + b; }
+////function foo() {
+////    return { x: 1, y: 1 };
 ////}
+////export default foo();
 
 verify.codeFixAvailable([
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message },
     { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message }
 ]);
 
@@ -16,9 +16,11 @@ verify.codeFix({
     description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message,
     index: 0,
     newFileContent:
-`const a = 42;
-const b = 42;
-export class C {
-  get property(): number { return a + b; }
-}`,
+`function foo() {
+    return { x: 1, y: 1 };
+}
+const __default: {
+    x: number; y: number;
+} = foo();
+export default __default;`,
 });

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports11.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports11.ts
@@ -1,0 +1,25 @@
+/// <reference path='fourslash.ts'/>
+
+// @isolatedDeclarations: true
+// @declaration: true
+//// function mixin<T extends new (...a: any) => any>(ctor: T): T {
+////     return ctor;
+//// }
+//// class Point2D { x = 0; y = 0; }
+//// export class Point3D extends mixin(Point2D) {  z = 0; }
+
+verify.codeFixAvailable([
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message }
+]);
+
+verify.codeFix({
+    description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message,
+    index: 0,
+    newFileContent:
+`function mixin<T extends new (...a: any) => any>(ctor: T): T {
+    return ctor;
+}
+class Point2D { x = 0; y = 0; }
+const Point3DBase: typeof Point2D = (mixin(Point2D));
+export class Point3D extends Point3DBase {  z = 0; }`
+});

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports12.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports12.ts
@@ -1,0 +1,30 @@
+/// <reference path='fourslash.ts'/>
+
+// @isolatedDeclarations: true
+// @declaration: true
+//// function mixin<T extends new (...a: any) => any>(ctor: T): T {
+////     return ctor;
+//// }
+//// class Point2D { x = 0; y = 0; }
+//// export const Point3D = class extends mixin(Point2D) {  z = 0; };
+
+verify.codeFixAvailable([
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message },
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message }
+]);
+
+// TODO: There's no easy way to name the type, so rather promoting this to a classDeclaration is better.
+verify.codeFix({
+    description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message,
+    index: 0,
+    newFileContent:
+`function mixin<T extends new (...a: any) => any>(ctor: T): T {
+    return ctor;
+}
+class Point2D { x = 0; y = 0; }
+export const Point3D: {
+        new(): {
+            z: number; x: number; y: number;
+        };
+    } = class extends mixin(Point2D) { z = 0; };`
+});

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports13.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports13.ts
@@ -1,0 +1,25 @@
+/// <reference path='fourslash.ts'/>
+
+// @isolatedDeclarations: true
+// @declaration: true
+//// function foo() {
+////     return { x: 1, y: 1 };
+//// }
+//// export const { x, y } = foo();
+
+verify.codeFixAvailable([
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message },
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message }
+]);
+
+verify.codeFix({
+    description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message,
+    index: 0,
+    newFileContent:
+`function foo() {
+    return { x: 1, y: 1 };
+}
+const dest = foo();
+export const x: number = dest.x;
+export const y: number = dest.y;`
+});

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports14.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports14.ts
@@ -1,0 +1,25 @@
+/// <reference path='fourslash.ts'/>
+
+// @isolatedDeclarations: true
+// @declaration: true
+//// function foo() {
+////     return { x: 1, y: 1 };
+//// }
+//// export const { x: abcd, y: defg } = foo();
+
+verify.codeFixAvailable([
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message },
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message }
+]);
+
+verify.codeFix({
+    description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message,
+    index: 0,
+    newFileContent:
+`function foo() {
+    return { x: 1, y: 1 };
+}
+const dest = foo();
+export const abcd: number = dest.x;
+export const defg: number = dest.y;`
+});

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports15.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports15.ts
@@ -1,0 +1,26 @@
+/// <reference path='fourslash.ts'/>
+
+// @isolatedDeclarations: true
+// @declaration: true
+//// function foo() {
+////     return { x: 1, y: 1};
+//// }
+//// export const { x, y = 0} = foo();
+
+verify.codeFixAvailable([
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message },
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message }
+]);
+
+verify.codeFix({
+    description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message,
+    index: 0,
+    newFileContent:
+`function foo() {
+    return { x: 1, y: 1};
+}
+const dest = foo();
+export const x: number = dest.x;
+const temp: number = dest.y;
+export const y: number = temp === undefined ? 0 : dest.y;`
+});

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports15.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports15.ts
@@ -21,6 +21,6 @@ verify.codeFix({
 }
 const dest = foo();
 export const x: number = dest.x;
-const temp: number = dest.y;
+const temp = dest.y;
 export const y: number = temp === undefined ? 0 : dest.y;`
 });

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports16.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports16.ts
@@ -21,6 +21,6 @@ verify.codeFix({
 }
 const dest = foo();
 export const x: 1 = dest.x;
-const temp: 1 | 0 = dest.y;
+const temp = dest.y;
 export const y: 1 | 0 = temp === undefined ? 0 : dest.y;`
 });

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports16.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports16.ts
@@ -1,0 +1,26 @@
+/// <reference path='fourslash.ts'/>
+
+// @isolatedDeclarations: true
+// @declaration: true
+//// function foo() {
+////     return { x: 1, y: 1 } as const;
+//// }
+//// export const { x, y = 0 } = foo();
+
+verify.codeFixAvailable([
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message },
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message }
+]);
+
+verify.codeFix({
+    description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message,
+    index: 0,
+    newFileContent:
+`function foo() {
+    return { x: 1, y: 1 } as const;
+}
+const dest = foo();
+export const x: 1 = dest.x;
+const temp: 1 | 0 = dest.y;
+export const y: 1 | 0 = temp === undefined ? 0 : dest.y;`
+});

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports17.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports17.ts
@@ -1,0 +1,32 @@
+/// <reference path='fourslash.ts'/>
+
+// @isolatedDeclarations: true
+// @declaration: true
+//// function foo() {
+////     return { x: 1, y: {42: {dd: "45"}, b: 2} };
+//// }
+//// function foo3(): "42" {
+////     return "42";
+//// }
+//// export const { x: a , y: { [foo3()]: {dd: e} } } = foo();
+
+verify.codeFixAvailable([
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message },
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message }
+]);
+
+verify.codeFix({
+    description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message,
+    index: 0,
+    newFileContent:
+`function foo() {
+    return { x: 1, y: {42: {dd: "45"}, b: 2} };
+}
+function foo3(): "42" {
+    return "42";
+}
+const dest = foo();
+export const a: number = dest.x;
+const _a = foo3();
+export const e: string = (dest.y)[_a].dd;`
+});

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports18.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports18.ts
@@ -15,5 +15,5 @@ verify.codeFix({
     description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message,
     index: 0,
     newFileContent:
-`export const x: typeof x = Symbol();`
+`export const a: typeof a = Symbol();`
 });

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports18.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports18.ts
@@ -1,0 +1,19 @@
+/// <reference path='fourslash.ts'/>
+
+// @isolatedDeclarations: true
+// @declaration: true
+// @lib: es2019
+//// export const a = Symbol();
+
+verify.codeFixAvailable([
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message },
+    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message }
+]);
+
+// TODO: the typeof operator here is wrong.
+verify.codeFix({
+    description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message,
+    index: 0,
+    newFileContent:
+`export const x: typeof x = Symbol();`
+});

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports2.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports2.ts
@@ -7,7 +7,6 @@
 ////export function foo() { return a + b; }
 
 verify.codeFixAvailable([
-    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message },
     { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message }
 ]);
 

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports4.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports4.ts
@@ -10,7 +10,6 @@
 
 verify.codeFixAvailable([
     { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message },
-    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message },
 ]);
 
 verify.codeFix({

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports7.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports7.ts
@@ -6,7 +6,6 @@
 ////export const c = {foo: foo()};
 
 verify.codeFixAvailable([
-    { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message },
     { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message }
 ]);
 


### PR DESCRIPTION
Code review will be easier to be done commit-by-commit.

This PR intends to support fixes for the following in the language-service fixer for type annotation

1. object, array destructuring
2. default exports
3. heritage clauses

Upcoming work:

1. Properly support the type generation for`Symbol()`s
2. Wrap the code-mod around the language service instead. I tried a bit but there were some files (external-declarations/tests/source/binder/re-exported-import-visibility.ts) that was causing module imports thus the language service itself failed, so I had to revert my changes.
3. Improve Diagnostics handling. Currently it occasionally prints multiple diagnostics for one thing. (e.g. For `export const c = [...foo()];` , it has diagnostics for `c` and for `foo`, thus the fixer also generates multiple fixes for the same thing.