### PR TITLE
Pick up changes from in the language service also to code-mod

### DIFF
--- a/external-declarations/fixer-test/expected/array_literals.ts
+++ b/external-declarations/fixer-test/expected/array_literals.ts
@@ -1,4 +1,4 @@
 export const a = [42, 34] as const;
 const b = [42, 34] as const;
-export const c = [42, 34];
+export const c: number[] = [42, 34];
 const d = [42, 34];

--- a/external-declarations/fixer-test/expected/classes.ts
+++ b/external-declarations/fixer-test/expected/classes.ts
@@ -1,0 +1,11 @@
+function mixin<T extends new (...a: any) => any>(ctor: T): T {
+    return ctor;
+}
+class Point2D {
+    x = 0;
+    y = 0;
+}
+const Point3DBase: typeof Point2D = (mixin(Point2D));
+export class Point3D extends Point3DBase {
+    z = 0;
+}

--- a/external-declarations/fixer-test/expected/default_exports.ts
+++ b/external-declarations/fixer-test/expected/default_exports.ts
@@ -1,0 +1,8 @@
+function foo() {
+    return { x: 1, y: 1 };
+}
+const __default: {
+    x: number;
+    y: number;
+} = foo();
+export default __default;

--- a/external-declarations/fixer-test/expected/destructuring.ts
+++ b/external-declarations/fixer-test/expected/destructuring.ts
@@ -1,0 +1,8 @@
+function foo() {
+    return { x: 1, y: 1 } as const;
+}
+const dest = foo();
+export const x: 1 = dest.x;
+const temp = dest.y;
+export const y: 1 | 0 = temp === undefined ? 0 : dest.y;
+export const z = 42;

--- a/external-declarations/fixer-test/expected/function_return.ts
+++ b/external-declarations/fixer-test/expected/function_return.ts
@@ -10,7 +10,7 @@ function foo2(a: number) {
     }
     return String(a);
 }
-export function singleReturn() {
+export function singleReturn(): number {
     return 42;
 }
 function singleReturn2() {
@@ -22,7 +22,7 @@ export function singleReturnNonLiteral(): string | 42 {
 function singleReturnNonLiteral2() {
     return foo(2);
 }
-export function multipleReturn(a: number) {
+export function multipleReturn(a: number): 42 | 43 {
     if (a === 0) {
         return 42;
     }
@@ -46,7 +46,10 @@ export function returnObjectLiteral(): {
         Button: makeResource("Label")
     };
 }
-export function returnObjectLiteral2() {
+export function returnObjectLiteral2(): {
+    Label: number;
+    Button: string;
+} {
     return {
         Label: 42,
         Button: "42"

--- a/external-declarations/fixer-test/expected/function_signatures_objects.ts
+++ b/external-declarations/fixer-test/expected/function_signatures_objects.ts
@@ -11,7 +11,11 @@ const b = {
     array: [1, 2, 3],
     fn(value: string): number { return 0; }
 } as const;
-export const c = {
+export const c: {
+    value: number;
+    array: number[];
+    fn(value: string): number;
+} = {
     value: 0,
     array: [1, 2, 3],
     fn(value: string): number { return 0; }

--- a/external-declarations/fixer-test/expected/object_literals.ts
+++ b/external-declarations/fixer-test/expected/object_literals.ts
@@ -6,7 +6,10 @@ const b = {
     value: 0,
     array: [1, 2, 3]
 } as const;
-export const c = {
+export const c: {
+    value: number;
+    array: number[];
+} = {
     value: 0,
     array: [1, 2, 3]
 };

--- a/external-declarations/fixer-test/source/classes.ts
+++ b/external-declarations/fixer-test/source/classes.ts
@@ -1,0 +1,5 @@
+function mixin<T extends new (...a: any) => any>(ctor: T): T {
+    return ctor;
+}
+class Point2D { x = 0; y = 0; }
+export class Point3D extends mixin(Point2D) { z = 0; }

--- a/external-declarations/fixer-test/source/default_exports.ts
+++ b/external-declarations/fixer-test/source/default_exports.ts
@@ -1,0 +1,4 @@
+function foo() {
+    return { x: 1, y: 1 };
+}
+export default foo();

--- a/external-declarations/fixer-test/source/destructuring.ts
+++ b/external-declarations/fixer-test/source/destructuring.ts
@@ -1,0 +1,4 @@
+function foo() {
+    return { x: 1, y: 1 } as const;
+}
+export const { x, y = 0 } = foo();

--- a/external-declarations/fixer-test/source/destructuring.ts
+++ b/external-declarations/fixer-test/source/destructuring.ts
@@ -1,4 +1,4 @@
 function foo() {
     return { x: 1, y: 1 } as const;
 }
-export const { x, y = 0 } = foo();
+export const { x, y = 0 } = foo(), z = 42;

--- a/external-declarations/src/code-mod/code-transform.ts
+++ b/external-declarations/src/code-mod/code-transform.ts
@@ -229,6 +229,17 @@ export function addTypeAnnotationTransformer(sourceFile: ts.SourceFile, program:
                 }
                 ++i;
             }
+
+            if (variableStatement.declarationList.declarations.length > 1) {
+                newNodes.push(ts.factory.updateVariableStatement(
+                    variableStatement,
+                    variableStatement.modifiers,
+                    ts.factory.updateVariableDeclarationList(
+                        variableStatement.declarationList,
+                        variableStatement.declarationList.declarations.filter((node) => node !== bindingPattern.parent),
+                        )
+                ));
+            }
             return newNodes;
         }
 

--- a/src/services/codefixes/fixMissingTypeAnnotationOnExports.ts
+++ b/src/services/codefixes/fixMissingTypeAnnotationOnExports.ts
@@ -373,6 +373,17 @@ function transformDestructuringPatterns(bindingPattern: BindingPattern,
         }
         ++i;
     }
+
+    if (enclosingVarStmt.declarationList.declarations.length > 1) {
+        newNodes.push(factory.updateVariableStatement(
+            enclosingVarStmt,
+            enclosingVarStmt.modifiers,
+            factory.updateVariableDeclarationList(
+                enclosingVarStmt.declarationList,
+                enclosingVarStmt.declarationList.declarations.filter((node) => node !== bindingPattern.parent),
+                )
+        ));
+    }
     changes.replaceNodeWithNodes(sourceFile, enclosingVarStmt, newNodes);
 }
 

--- a/src/services/codefixes/fixMissingTypeAnnotationOnExports.ts
+++ b/src/services/codefixes/fixMissingTypeAnnotationOnExports.ts
@@ -53,7 +53,7 @@ const canHaveExplicitTypeAnnotation = new Set<SyntaxKind>([
     SyntaxKind.VariableDeclaration,
     SyntaxKind.Parameter,
     SyntaxKind.ExportAssignment,
-    SyntaxKind.ExpressionWithTypeArguments,
+    SyntaxKind.ClassDeclaration,
     SyntaxKind.ObjectBindingPattern,
     SyntaxKind.ArrayBindingPattern,
 ]);
@@ -85,7 +85,7 @@ registerCodeFix({
 
 function doChange(changes: textChanges.ChangeTracker, sourceFile: SourceFile, typeChecker: TypeChecker, nodeWithDiag: Node): void {
     const nodeWithNoType = findNearestParentWithTypeAnnotation(nodeWithDiag);
-    fixupForIsolatedDeclarations(nodeWithNoType, sourceFile, typeChecker, changes);
+    fixupForIsolatedDeclarations(nodeWithNoType, nodeWithDiag, sourceFile, typeChecker, changes);
 }
 
 // Currently, the diagnostics for the error is not given in the exact node of which that needs type annotation
@@ -101,7 +101,7 @@ function findNearestParentWithTypeAnnotation(node: Node): Node {
  * Fixes up to support IsolatedDeclaration by either adding types when possible, or splitting statements and add type annotations
  * for the places that cannot have type annotations (e.g. HeritageClause, default exports, ...)
  */
-function fixupForIsolatedDeclarations(node: Node, sourceFile: SourceFile, typeChecker: TypeChecker, changes: textChanges.ChangeTracker) {
+function fixupForIsolatedDeclarations(node: Node, nodeWithDiag: Node, sourceFile: SourceFile, typeChecker: TypeChecker, changes: textChanges.ChangeTracker) {
     switch (node.kind) {
     case SyntaxKind.Parameter:
         const parameter = node as ParameterDeclaration;
@@ -217,31 +217,8 @@ function fixupForIsolatedDeclarations(node: Node, sourceFile: SourceFile, typeCh
         }
         break;
     // Handling expression like heritage clauses e.g. class A extends mixin(B) ..
-    case SyntaxKind.ExpressionWithTypeArguments:
-        const expression = node as ExpressionWithTypeArguments;
-        const classDecl = expression.parent.parent as unknown as ClassDeclaration;
-        const heritageTypeNode = typeToTypeNode(
-            typeChecker.getTypeAtLocation(expression.expression),
-            expression.expression,
-            typeChecker);
-        const heritageVariableName = factory.createUniqueName(
-            classDecl.name? classDecl.name.text + "Base" : "Anonymous", GeneratedIdentifierFlags.Optimistic);
-        // e.g. const Point3DBase: typeof Point2D = mixin(Point2D);
-        const heritageVariable = factory.createVariableStatement(
-            /*modifiers*/ undefined,
-            factory.createVariableDeclarationList(
-                [factory.createVariableDeclaration(
-                    heritageVariableName,
-                    /*exclamationToken*/ undefined,
-                    heritageTypeNode,
-                    expression,
-                    )],
-                NodeFlags.Const,
-            )
-        );
-        changes.insertNodeAt(sourceFile, classDecl.getFullStart(), heritageVariable, { prefix: "\n" });
-        return changes.replaceNodeWithNodes(sourceFile, expression,
-            [factory.createExpressionWithTypeArguments(heritageVariableName, [])]);
+    case SyntaxKind.ClassDeclaration:
+        return handleClassDeclaration(node as ClassDeclaration, nodeWithDiag.parent.parent as ExpressionWithTypeArguments, sourceFile, changes, typeChecker);
     case SyntaxKind.ObjectBindingPattern:
     case SyntaxKind.ArrayBindingPattern:
         return transformDestructuringPatterns(node as BindingPattern, sourceFile, typeChecker, changes);
@@ -251,6 +228,48 @@ function fixupForIsolatedDeclarations(node: Node, sourceFile: SourceFile, typeCh
     throw new Error(`Cannot find a fix for the given node ${node.kind}`);
 }
 
+function handleClassDeclaration(classDecl: ClassDeclaration, heritageExpression: ExpressionWithTypeArguments, sourceFile: SourceFile, changes: textChanges.ChangeTracker, typeChecker: TypeChecker) {
+    if (heritageExpression.kind !== SyntaxKind.ExpressionWithTypeArguments){
+        throw new Error(`Hey + ${heritageExpression.kind}`);
+    }
+    const heritageTypeNode = typeToTypeNode(
+        typeChecker.getTypeAtLocation(heritageExpression.expression),
+        heritageExpression.expression,
+        typeChecker);
+    const heritageVariableName = factory.createUniqueName(
+        classDecl.name? classDecl.name.text + "Base" : "Anonymous", GeneratedIdentifierFlags.Optimistic);
+    // e.g. const Point3DBase: typeof Point2D = mixin(Point2D);
+    const heritageVariable = factory.createVariableStatement(
+        /*modifiers*/ undefined,
+        factory.createVariableDeclarationList(
+            [factory.createVariableDeclaration(
+                heritageVariableName,
+                /*exclamationToken*/ undefined,
+                heritageTypeNode,
+                heritageExpression,
+                )],
+            NodeFlags.Const,
+        )
+    );
+    changes.replaceNodeWithNodes(sourceFile, classDecl,
+        [heritageVariable,
+            factory.updateClassDeclaration(
+                classDecl,
+                classDecl.modifiers,
+                classDecl.name,
+                classDecl.typeParameters,
+                classDecl.heritageClauses?.map(
+                    (node) => {
+                        if (node === heritageExpression.parent) {
+                            return factory.updateHeritageClause(node,
+                                [factory.createExpressionWithTypeArguments(heritageVariableName, [])]
+                            );
+                        }
+                        return node;
+                    }),
+                classDecl.members)
+            ]);
+}
 
 interface ExpressionReverseChain {
     element?: BindingElement;

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports11.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports11.ts
@@ -21,5 +21,7 @@ verify.codeFix({
 }
 class Point2D { x = 0; y = 0; }
 const Point3DBase: typeof Point2D = (mixin(Point2D));
-export class Point3D extends Point3DBase {  z = 0; }`
+export class Point3D extends Point3DBase {
+    z = 0;
+}`
 });

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports15.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports15.ts
@@ -5,7 +5,7 @@
 //// function foo() {
 ////     return { x: 1, y: 1};
 //// }
-//// export const { x, y = 0} = foo();
+//// export const { x, y = 0} = foo(), z= 42;
 
 verify.codeFixAvailable([
     { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message },
@@ -22,5 +22,5 @@ verify.codeFix({
 const dest = foo();
 export const x: number = dest.x;
 const temp = dest.y;
-export const y: number = temp === undefined ? 0 : dest.y;`
-});
+export const y: number = temp === undefined ? 0 : dest.y;
+export const z = 42;`});


### PR DESCRIPTION
Eventually, code-mod should be a wrapper around the language service,

but there were some complications in doing that, so migrating the code to unblock from using the code-mod binary.

Review would be ideal if done commit-by-commit