### PR TITLE
When annotating for function expressions

### DIFF
--- a/external-declarations/fixer-test/expected/function_expressions.ts
+++ b/external-declarations/fixer-test/expected/function_expressions.ts
@@ -1,0 +1,9 @@
+function foo() {
+    return 42;
+}
+export class A {
+    readonly b = (): number => foo();
+    readonly c = function (): number { return foo(); };
+}
+export const b = (): number => foo();
+export const c = function (): number { return foo(); };

--- a/external-declarations/fixer-test/source/function_expressions.ts
+++ b/external-declarations/fixer-test/source/function_expressions.ts
@@ -1,0 +1,11 @@
+function foo() {
+    return 42;
+}
+
+export class A {
+    readonly b = () => foo();
+    readonly c = function() { return foo(); };
+}
+
+export const b = () => foo();
+export const c = function() { return foo(); };

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports19.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports19.ts
@@ -2,8 +2,9 @@
 
 // @isolatedDeclarations: true
 // @declaration: true
-////function foo() {return 42;}
-////export const g = function () { return foo(); };
+//// export class A {
+////     readonly a = function foo() {return 42;}
+//// }
 
 verify.codeFixAvailable([
     { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message },
@@ -14,6 +15,7 @@ verify.codeFix({
     description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message,
     index: 0,
     newFileContent:
-`function foo() {return 42;}
-export const g = function(): number { return foo(); };`,
+`export class A {
+    readonly a = function foo(): number { return 42; }
+}`
 });

--- a/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports20.ts
+++ b/tests/cases/fourslash/codeFixMissingTypeAnnotationOnExports20.ts
@@ -2,8 +2,10 @@
 
 // @isolatedDeclarations: true
 // @declaration: true
-////function foo() {return 42;}
-////export const g = function () { return foo(); };
+//// function foo() { return 42; }
+//// export class A {
+////     readonly a = () => foo();
+//// }
 
 verify.codeFixAvailable([
     { description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message },
@@ -14,6 +16,8 @@ verify.codeFix({
     description: ts.Diagnostics.Declaration_emit_for_this_file_requires_type_resolution_An_explicit_type_annotation_may_unblock_declaration_emit.message,
     index: 0,
     newFileContent:
-`function foo() {return 42;}
-export const g = function(): number { return foo(); };`,
+`function foo() { return 42; }
+export class A {
+    readonly a = (): number => foo();
+}`
 });


### PR DESCRIPTION
prefer adding type annotation on the function rather than on variables to reduce the size of the diff.
