### PR TITLE
Disallow enum member assigning from non-members in IsolatedDeclaration mode.

### DIFF
--- a/external-declarations/src/main.ts
+++ b/external-declarations/src/main.ts
@@ -79,7 +79,7 @@ async function main(cancellationToken: CancellationToken, msDelay: number) {
 
     const tsconfig = ts.readConfigFile(projectConfig, ts.sys.readFile);
     const parsed = ts.parseJsonConfigFileContent(tsconfig.config, ts.sys, "./");
-    const options = parsed.options;
+    const options = { ...parsed.options, isolatedDeclarations: true };
     if (parsedArgs.declarationDir) {
         options.declarationDir = parsedArgs.declarationDir;
     }

--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -1927,17 +1927,14 @@ export function transformDeclarations(context: TransformationContext) {
                     input.name,
                     factory.createNodeArray(mapDefined(input.members, m => {
                         if (shouldStripInternal(m)) return;
-                        if (isolatedDeclarations) {
-                            if (
-                                m.initializer && !resolver.isLiteralConstDeclaration(m) &&
-                                // This will be its own compiler error instead, so don't report.
-                                !isComputedPropertyName(m.name)
-                            ) {
-                                reportIsolatedDeclarationError(m);
-                            }
-                        }
                         // Rewrite enum values to their constants, if available
                         const constValue = resolver.getConstantValue(m);
+                        if (isolatedDeclarations && m.initializer && constValue === undefined &&
+                            // This will be its own compiler error instead, so don't report.
+                            !isComputedPropertyName(m.name) 
+                        ) {
+                            reportIsolatedDeclarationError(m);
+                        }
                         const newInitializer = constValue === undefined
                             ? undefined
                             : typeof constValue === "string"


### PR DESCRIPTION
I tried to find a way to merge the two different evaluators, but the two functions' call path was in a way that it actually makes this difficult to achieve it. 

So rather, I made a slight modification on how the `getConstValue` is used, as beneath it's calling into evaluator.

