### PR TITLE
Update the reason for not fixing types

### DIFF
--- a/tests/baselines/reference/isolated-declarations/auto-fixed/diff/nodeModulesExportsBlocksSpecifierResolution(module=node16).d.ts.diff
+++ b/tests/baselines/reference/isolated-declarations/auto-fixed/diff/nodeModulesExportsBlocksSpecifierResolution(module=node16).d.ts.diff
@@ -1,4 +1,4 @@
-// [[Reason: TODO Seems to be missing enough semantic info to fix]] ////
+// [[Reason: checker.typeToTypeNode fails on types that originate from node_module]] ////
 
 //// [tests/cases/conformance/node/nodeModulesExportsBlocksSpecifierResolution.ts] ////
 

--- a/tests/baselines/reference/isolated-declarations/auto-fixed/diff/nodeModulesExportsBlocksSpecifierResolution(module=nodenext).d.ts.diff
+++ b/tests/baselines/reference/isolated-declarations/auto-fixed/diff/nodeModulesExportsBlocksSpecifierResolution(module=nodenext).d.ts.diff
@@ -1,4 +1,4 @@
-// [[Reason: TODO Seems to be missing enough semantic info to fix]] ////
+// [[Reason: checker.typeToTypeNode fails on types that originate from node_module]] ////
 
 //// [tests/cases/conformance/node/nodeModulesExportsBlocksSpecifierResolution.ts] ////
 

--- a/tests/baselines/reference/isolated-declarations/auto-fixed/diff/nodeModulesExportsSourceTs(module=node16).d.ts.diff
+++ b/tests/baselines/reference/isolated-declarations/auto-fixed/diff/nodeModulesExportsSourceTs(module=node16).d.ts.diff
@@ -1,4 +1,4 @@
-// [[Reason: TODO Seems to be missing enough semantic info to fix]] ////
+// [[Reason: checker.typeToTypeNode fails on types that originate from node_module]] ////
 
 //// [tests/cases/conformance/node/nodeModulesExportsSourceTs.ts] ////
 

--- a/tests/baselines/reference/isolated-declarations/auto-fixed/diff/nodeModulesExportsSourceTs(module=nodenext).d.ts.diff
+++ b/tests/baselines/reference/isolated-declarations/auto-fixed/diff/nodeModulesExportsSourceTs(module=nodenext).d.ts.diff
@@ -1,4 +1,4 @@
-// [[Reason: TODO Seems to be missing enough semantic info to fix]] ////
+// [[Reason: checker.typeToTypeNode fails on types that originate from node_module]] ////
 
 //// [tests/cases/conformance/node/nodeModulesExportsSourceTs.ts] ////
 

--- a/tests/baselines/reference/isolated-declarations/auto-fixed/diff/nodeModulesExportsSpecifierGenerationConditions(module=node16).d.ts.diff
+++ b/tests/baselines/reference/isolated-declarations/auto-fixed/diff/nodeModulesExportsSpecifierGenerationConditions(module=node16).d.ts.diff
@@ -1,4 +1,4 @@
-// [[Reason: TODO Seems to be missing enough semantic info to fix]] ////
+// [[Reason: checker.typeToTypeNode fails on types that originate from node_module]] ////
 
 //// [tests/cases/conformance/node/nodeModulesExportsSpecifierGenerationConditions.ts] ////
 

--- a/tests/baselines/reference/isolated-declarations/auto-fixed/diff/nodeModulesExportsSpecifierGenerationConditions(module=nodenext).d.ts.diff
+++ b/tests/baselines/reference/isolated-declarations/auto-fixed/diff/nodeModulesExportsSpecifierGenerationConditions(module=nodenext).d.ts.diff
@@ -1,4 +1,4 @@
-// [[Reason: TODO Seems to be missing enough semantic info to fix]] ////
+// [[Reason: checker.typeToTypeNode fails on types that originate from node_module]] ////
 
 //// [tests/cases/conformance/node/nodeModulesExportsSpecifierGenerationConditions.ts] ////
 

--- a/tests/baselines/reference/isolated-declarations/auto-fixed/diff/nodeModulesExportsSpecifierGenerationDirectory(module=node16).d.ts.diff
+++ b/tests/baselines/reference/isolated-declarations/auto-fixed/diff/nodeModulesExportsSpecifierGenerationDirectory(module=node16).d.ts.diff
@@ -1,4 +1,4 @@
-// [[Reason: TODO Seems to be missing enough semantic info to fix]] ////
+// [[Reason: checker.typeToTypeNode fails on types that originate from node_module]] ////
 
 //// [tests/cases/conformance/node/nodeModulesExportsSpecifierGenerationDirectory.ts] ////
 

--- a/tests/baselines/reference/isolated-declarations/auto-fixed/diff/nodeModulesExportsSpecifierGenerationDirectory(module=nodenext).d.ts.diff
+++ b/tests/baselines/reference/isolated-declarations/auto-fixed/diff/nodeModulesExportsSpecifierGenerationDirectory(module=nodenext).d.ts.diff
@@ -1,4 +1,4 @@
-// [[Reason: TODO Seems to be missing enough semantic info to fix]] ////
+// [[Reason: checker.typeToTypeNode fails on types that originate from node_module]] ////
 
 //// [tests/cases/conformance/node/nodeModulesExportsSpecifierGenerationDirectory.ts] ////
 

--- a/tests/baselines/reference/isolated-declarations/auto-fixed/diff/nodeModulesExportsSpecifierGenerationPattern(module=node16).d.ts.diff
+++ b/tests/baselines/reference/isolated-declarations/auto-fixed/diff/nodeModulesExportsSpecifierGenerationPattern(module=node16).d.ts.diff
@@ -1,4 +1,4 @@
-// [[Reason: TODO Seems to be missing enough semantic info to fix]] ////
+// [[Reason: checker.typeToTypeNode fails on types that originate from node_module]] ////
 
 //// [tests/cases/conformance/node/nodeModulesExportsSpecifierGenerationPattern.ts] ////
 

--- a/tests/baselines/reference/isolated-declarations/auto-fixed/diff/nodeModulesExportsSpecifierGenerationPattern(module=nodenext).d.ts.diff
+++ b/tests/baselines/reference/isolated-declarations/auto-fixed/diff/nodeModulesExportsSpecifierGenerationPattern(module=nodenext).d.ts.diff
@@ -1,4 +1,4 @@
-// [[Reason: TODO Seems to be missing enough semantic info to fix]] ////
+// [[Reason: checker.typeToTypeNode fails on types that originate from node_module]] ////
 
 //// [tests/cases/conformance/node/nodeModulesExportsSpecifierGenerationPattern.ts] ////
 

--- a/tests/cases/conformance/node/nodeModulesExportsBlocksSpecifierResolution.ts
+++ b/tests/cases/conformance/node/nodeModulesExportsBlocksSpecifierResolution.ts
@@ -1,6 +1,6 @@
 // @module: node16,nodenext
 // @declaration: true
-// @isolatedDeclarationFixedDiffReason: TODO Seems to be missing enough semantic info to fix
+// @isolatedDeclarationFixedDiffReason: checker.typeToTypeNode fails on types that originate from node_module.
 // @filename: index.ts
 // esm format file
 import { Thing } from "inner/other";

--- a/tests/cases/conformance/node/nodeModulesExportsSourceTs.ts
+++ b/tests/cases/conformance/node/nodeModulesExportsSourceTs.ts
@@ -1,6 +1,6 @@
 // @module: node16,nodenext
 // @declaration: true
-// @isolatedDeclarationFixedDiffReason: TODO Seems to be missing enough semantic info to fix
+// @isolatedDeclarationFixedDiffReason: checker.typeToTypeNode fails on types that originate from node_module.
 // @filename: index.ts
 // esm format file
 import { Thing } from "inner/other";

--- a/tests/cases/conformance/node/nodeModulesExportsSpecifierGenerationConditions.ts
+++ b/tests/cases/conformance/node/nodeModulesExportsSpecifierGenerationConditions.ts
@@ -1,6 +1,6 @@
 // @module: node16,nodenext
 // @declaration: true
-// @isolatedDeclarationFixedDiffReason: TODO Seems to be missing enough semantic info to fix
+// @isolatedDeclarationFixedDiffReason: checker.typeToTypeNode fails on types that originate from node_module.
 // @filename: index.ts
 // esm format file
 import { Thing } from "inner/other.js"; // should fail

--- a/tests/cases/conformance/node/nodeModulesExportsSpecifierGenerationDirectory.ts
+++ b/tests/cases/conformance/node/nodeModulesExportsSpecifierGenerationDirectory.ts
@@ -1,6 +1,6 @@
 // @module: node16,nodenext
 // @declaration: true
-// @isolatedDeclarationFixedDiffReason: TODO Seems to be missing enough semantic info to fix
+// @isolatedDeclarationFixedDiffReason: checker.typeToTypeNode fails on types that originate from node_module.
 // @filename: index.ts
 // esm format file
 import { Thing } from "inner/other";

--- a/tests/cases/conformance/node/nodeModulesExportsSpecifierGenerationPattern.ts
+++ b/tests/cases/conformance/node/nodeModulesExportsSpecifierGenerationPattern.ts
@@ -1,6 +1,6 @@
 // @module: node16,nodenext
 // @declaration: true
-// @isolatedDeclarationFixedDiffReason: TODO Seems to be missing enough semantic info to fix
+// @isolatedDeclarationFixedDiffReason: checker.typeToTypeNode fails on types that originate from node_module.
 // @filename: index.ts
 // esm format file
 import { Thing } from "inner/other";


### PR DESCRIPTION
These type originate from node_modules and as the compiler refuses to create proper type node for them as it would be adding an import to node_modules. We also don't do anything about it.

